### PR TITLE
@feature/scheduling

### DIFF
--- a/prisma/migrations/20250105113340_add_exchange_rate_daily_table/migration.sql
+++ b/prisma/migrations/20250105113340_add_exchange_rate_daily_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "exchange_rates_daily" (
+    "idx" SERIAL NOT NULL,
+    "base_currency" CHAR(3) NOT NULL,
+    "currency_code" CHAR(3) NOT NULL,
+    "date" DATE NOT NULL,
+    "open_rate" DECIMAL(20,8) NOT NULL,
+    "high_rate" DECIMAL(20,8) NOT NULL,
+    "low_rate" DECIMAL(20,8) NOT NULL,
+    "close_rate" DECIMAL(20,8) NOT NULL,
+    "avg_rate" DECIMAL(20,8) NOT NULL,
+    "rate_count" INTEGER NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "exchange_rates_daily_pkey" PRIMARY KEY ("idx")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_exchange_rates_daily_lookup" ON "exchange_rates_daily"("currency_code", "base_currency", "date" DESC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "exchange_rates_daily_unique" ON "exchange_rates_daily"("currency_code", "base_currency", "date");

--- a/src/apis/exchange-rate/exchange-rate.controller.ts
+++ b/src/apis/exchange-rate/exchange-rate.controller.ts
@@ -3,10 +3,10 @@ import { ApiTags } from '@nestjs/swagger';
 import {
   CurrentExchangeRateReqDto,
   CurrentExchangeRateResDto,
-} from './dto/current-exchange-rate.dto';
+} from './dto/exchange-rates.dto';
 import { ApiSuccess } from '../../decorators/swaggers/success.decorator';
 import { ApiExceptions } from '../../decorators/swaggers/exception.decorator';
-import { CurrentExchangeHistoryReqDto } from './dto/current-exchange-history.dto';
+import { CurrentExchangeHistoryReqDto } from './dto/exchange-rates-history.dto';
 import { InvalidCurrencyCodeException } from '../../decorators/validations/exceptions/invalid-currency-code';
 import { ExchangeRateService } from './exchange-rate.service';
 

--- a/src/apis/exchange-rate/exchange-rate.module.ts
+++ b/src/apis/exchange-rate/exchange-rate.module.ts
@@ -4,10 +4,17 @@ import { ExchangeRateController } from './exchange-rate.controller';
 import { FixerModule } from '../fixer/fixer.module';
 import { RedisModule } from '../../redis/redis.module';
 import { DateUtilModule } from '../../utils/date-util/date-util.module';
+import { ScheduleModule } from '@nestjs/schedule';
+import { ExchageRateScheduler } from './schedulers/exchange-rate.scheduler';
+import { ExchangeRateRepository } from './exchange-rate.repository';
 
 @Module({
-  imports: [FixerModule, RedisModule, DateUtilModule],
+  imports: [FixerModule, RedisModule, DateUtilModule, ScheduleModule.forRoot()],
   controllers: [ExchangeRateController],
-  providers: [ExchangeRateService],
+  providers: [
+    ExchangeRateService,
+    ExchageRateScheduler,
+    ExchangeRateRepository,
+  ],
 })
 export class ExchangeRateModule {}

--- a/src/apis/exchange-rate/exchange-rate.repository.ts
+++ b/src/apis/exchange-rate/exchange-rate.repository.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { IExchangeRate } from './interface/exchange-rate.interface';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class ExchangeRateRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async intertMany(
+    input: IExchangeRate.ICreateMany,
+    tx?: Prisma.TransactionClient,
+  ) {
+    await (tx ?? this.prisma).exchangeRates.createMany({
+      data: input,
+    });
+  }
+}

--- a/src/apis/exchange-rate/exchange-rate.service.ts
+++ b/src/apis/exchange-rate/exchange-rate.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { RedisService } from '../../redis/redis.service';
 import { MockFixerService } from '../fixer/mock/fixer-mock.service';
-import { DateUtilService } from '../../utils/date-util/date-util.service';
+import { ExchangeRateRepository } from './exchange-rate.repository';
+import { IExchangeRate } from './interface/exchange-rate.interface';
+import { RedisService } from '../../redis/redis.service';
 
 @Injectable()
 export class ExchangeRateService {
   constructor(
     private readonly fixerService: MockFixerService,
+    private readonly exchangeRateRepository: ExchangeRateRepository,
     private readonly redisService: RedisService,
-    private readonly dateUtilService: DateUtilService,
   ) {}
 
   async getCurrencyExchangeRates(
@@ -24,5 +25,30 @@ export class ExchangeRateService {
       latestRates,
       fluctuationRates,
     };
+  }
+
+  /**
+   * Performing tasks following caching strategies
+   *
+   * 1. get latest-rate from external API
+   * 2. convert recived data to record for RDB
+   * 3. update cache
+   */
+  async saveLatestRates(): Promise<void> {
+    const rates = await this.fixerService.getLatestRates();
+    const baseCurrency = rates.base;
+    const records: IExchangeRate.ICreateMany = Object.entries(rates.rates).map(
+      ([currencyCode, rate]) => ({
+        baseCurrency,
+        currencyCode,
+        rate,
+      }),
+    );
+
+    // TODO: distribute transaction & analize excution time
+    await Promise.all([
+      this.exchangeRateRepository.intertMany(records),
+      this.redisService.updateLatestRateCache(records),
+    ]);
   }
 }

--- a/src/apis/exchange-rate/interface/exchange-rate.interface.ts
+++ b/src/apis/exchange-rate/interface/exchange-rate.interface.ts
@@ -1,0 +1,9 @@
+export namespace IExchangeRate {
+  export interface ICreate {
+    baseCurrency: string;
+    currencyCode: string;
+    rate: number;
+  }
+
+  export interface ICreateMany extends Array<ICreate> {}
+}

--- a/src/apis/exchange-rate/schedulers/exchange-rate.scheduler.ts
+++ b/src/apis/exchange-rate/schedulers/exchange-rate.scheduler.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ExchangeRateService } from '../exchange-rate.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+@Injectable()
+export class ExchageRateScheduler {
+  private readonly logger: Logger = new Logger(ExchageRateScheduler.name);
+
+  constructor(private readonly exchangeRateService: ExchangeRateService) {}
+
+  /**
+   * Collects real-time currency rate data every 10 minutes
+   *
+   * Process:
+   * 1. Collect latest exchange rates from Fixer API
+   * 2. Save to the RDB (PostgreSQL)
+   * 3. Update Redis Cache
+   *
+   * @throws {FixerAPIException} When API call fails
+   * @throws {DatabaseException} When database operation fails
+   */
+  @Cron(CronExpression.EVERY_MINUTE)
+  async aggregateLatestRates() {
+    try {
+      await this.exchangeRateService.saveLatestRates();
+
+      this.logger.log('Successfully collected latest rates');
+    } catch (error) {
+      this.logger.error('Failed to aggregate daily rates', error);
+    }
+  }
+
+  /**
+   * Aggregates daily exchange rate statistics at midnight (UTC)
+   *
+   * Process:
+   * 1. Aggregates previous day's exchange rates (00:00 ~ 23:59)
+   * 2. Calculates OHLC (Open, High, Low, Close)
+   * 3. Stores daily statistics in exchange_rates_daily
+   *
+   * @throws {DatabaseException} When database operation fails
+   */
+  @Cron('5 0 * * *') // UTC 00:05
+  async aggregateDailyRates() {
+    try {
+      this.logger.log('Successfully collected daily rates');
+    } catch (error) {
+      this.logger.error('Failed to aggregate daily rates', error);
+    }
+  }
+}

--- a/src/redis/interface/currency-rate.interface.ts
+++ b/src/redis/interface/currency-rate.interface.ts
@@ -1,0 +1,4 @@
+export interface LatestRateCache {
+  rate: number;
+  updatedAt: Date;
+}

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,8 +1,7 @@
 import { Logger, Module } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { ConfigService } from '@nestjs/config';
-import { Redis } from 'ioredis';
-
+import Redis from 'ioredis';
 @Module({
   providers: [
     {

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -1,14 +1,42 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Redis } from 'ioredis';
+import { IExchangeRate } from '../apis/exchange-rate/interface/exchange-rate.interface';
+import { LatestRateCache } from './interface/currency-rate.interface';
 
 @Injectable()
 export class RedisService implements OnModuleInit {
+  private readonly CACHE_TTL = {
+    CURRENT_RATES: 15 * 60, // 15 min
+  };
+
   constructor(
     @Inject('REDIS_CLIENT') private readonly redisClient: Redis,
     private readonly logger: Logger,
     private readonly configService: ConfigService,
   ) {}
+
+  /**
+   * Update real-time currency rate to the redis
+   */
+  async updateLatestRateCache(
+    rates: IExchangeRate.ICreateMany,
+    ttl = this.CACHE_TTL.CURRENT_RATES,
+  ) {
+    await Promise.all(
+      rates.map((rate) =>
+        this.redisClient.set(
+          `rate:${rate.baseCurrency}:${rate.currencyCode}`,
+          JSON.stringify(<LatestRateCache>{
+            rate: rate.rate,
+            updatedAt: new Date(),
+          }),
+          'EX',
+          Number(ttl),
+        ),
+      ),
+    );
+  }
 
   onModuleInit() {
     this.redisClient.on('ready', () => {
@@ -18,23 +46,5 @@ export class RedisService implements OnModuleInit {
     this.redisClient.on('error', (error) => {
       this.logger.error(`Redis client error: ${error}`);
     });
-  }
-
-  async get(key: string): Promise<string | null> {
-    return this.redisClient.get(`session:${key}`);
-  }
-
-  /**
-   * 세션 사용시
-   */
-  async set(key: string): Promise<void> {
-    this.redisClient.set(
-      `session:admin`,
-      key,
-      'EX',
-      60 * 60 * this.configService.get('DEFAUT_SESSION_HOURS'),
-    );
-
-    return;
   }
 }


### PR DESCRIPTION
Exchange rate data collection Strategy Implementation.

### 1. Define Data Auto-Scheduling Strategy
- Latest rates collection (every 10-min intervers)
- Daily OHLC data aggregation
- UTC-based scheduling

### 2. Add Exchange Rate Scheduler
- Collect latest rates every 10 minutes (use external API)
- Aggregate daily statistics at UTC (00:05)

### 3. Define Caching Stragegy
- Cache TTL: 15 min (schedular interver + buffer)
- Define cache key pattern.

