### PR TITLE
[Feat]: Add ExchangeRate caching

### DIFF
--- a/src/modules/exchange-rate/__test__/unit/exchange-rate.service.spec.ts
+++ b/src/modules/exchange-rate/__test__/unit/exchange-rate.service.spec.ts
@@ -188,6 +188,106 @@ describe('ExchangeRateService', () => {
       ).not.toThrow();
     });
 
+    describe('Redis caching', () => {
+      let externalLatestRateSpy;
+      let externalFluctuationSpy;
+
+      beforeEach(() => {
+        externalFluctuationSpy = jest.spyOn(
+          fluctuationExchangeRateApi,
+          'getFluctuationData',
+        );
+        externalLatestRateSpy = jest.spyOn(
+          latestExchangeRateApi,
+          'getLatestRates',
+        );
+      });
+
+      it('should return exchange-rates from Redis when cache was hitted', async () => {
+        // Arrange
+        const baseCurrency = 'KRW';
+        const recentUpdateCacheDate = new Date(); // 캐시된 최신 데이터
+        exchangeRateRedisService.latestRateHealthCheck.mockResolvedValue(
+          recentUpdateCacheDate,
+        );
+        exchangeRateRedisService.getLatestRate.mockResolvedValue([
+          '0.000662', // rate
+          '11.788303000000042', // dayChange
+          '0.7870123194679027', // daychangePercent
+          `${recentUpdateCacheDate.getTime()}`, // timestamp
+        ]);
+
+        // Act
+        const result = await exchangeRateService.getCurrencyExchangeRates({
+          baseCurrency,
+        });
+
+        // Assert
+        expect(externalLatestRateSpy).not.toHaveBeenCalled();
+        expect(externalFluctuationSpy).not.toHaveBeenCalled();
+        expect(Object.keys(result.rates)).toHaveLength(31); // 전체 통화쌍 데이터
+        expect(() =>
+          typia.assertEquals<CurrentExchangeRateResDto>(result),
+        ).not.toThrow();
+      });
+
+      it('should fetch from externalAPI when healthcheck is older than threshold', async () => {
+        // Arrange
+        const baseCurrency = 'KRW';
+        const recentUpdateCacheDate = new Date(Date.now() - 15000); // 15초 전 캐시된 데이터
+        exchangeRateRedisService.latestRateHealthCheck.mockResolvedValue(
+          recentUpdateCacheDate,
+        );
+        exchangeRateRedisService.getLatestRate.mockResolvedValue([
+          '0.000662', // rate
+          '11.788303000000042', // dayChange
+          '0.7870123194679027', // daychangePercent
+          `${recentUpdateCacheDate.getTime()}`, // timestamp
+        ]);
+        const mockLatestRates = ExchangeRateFixture.createLatestRates(
+          baseCurrency,
+          Object.fromEntries(
+            supportCurrencyList.map((currency) => [currency, 1]),
+          ),
+        );
+        const mockFluctuation = ExchangeRateFixture.createFluctuationRates(
+          baseCurrency,
+          new Date(),
+          new Date(),
+          Object.fromEntries(
+            supportCurrencyList.map((currency) => [
+              currency,
+              {
+                startRate: 1,
+                endRate: 1,
+                change: 1,
+                changePct: 1,
+                highRate: 2,
+                lowRate: 1.5,
+              },
+            ]),
+          ),
+        );
+        latestExchangeRateApi.getLatestRates.mockResolvedValue(mockLatestRates);
+        fluctuationExchangeRateApi.getFluctuationData.mockResolvedValue(
+          mockFluctuation,
+        );
+
+        // Act
+        const result = await exchangeRateService.getCurrencyExchangeRates({
+          baseCurrency,
+        });
+
+        // Assert
+        expect(externalLatestRateSpy).toHaveBeenCalled();
+        expect(externalFluctuationSpy).toHaveBeenCalled();
+        expect(Object.keys(result.rates)).toHaveLength(31); // 전체 통화쌍 데이터
+        expect(() =>
+          typia.assertEquals<CurrentExchangeRateResDto>(result),
+        ).not.toThrow();
+      });
+    });
+
     it.todo('hadnling external API(ratesRate)');
 
     it.todo('handling external API(fluctuationRate)');
@@ -456,19 +556,19 @@ describe('ExchangeRateService', () => {
     const latestRate = 1580;
     const latestTimestamp = new Date().getTime();
 
-    describe('해당 통화쌍에 대한 hash데이터가 존재할 경우', () => {
+    describe('모든 작업이 수행 된 후', () => {
       it('소켓으로 받은 latest-rate 데이터를 모두 rdb에 삽입한다', async () => {
         // Arrange
         exchangeRateRedisService.getLatestRate.mockResolvedValue([
           `${latestRate}`,
           `${latestTimestamp}`,
         ]);
-
-        // Act
         const createRateInRawSpy = jest.spyOn(
           exchangeRateRawRepository,
           'createExchangeRate',
         );
+
+        // Act
         await exchangeRateService.processLatestRateFromWS(
           baseCurrency,
           currencyCode,
@@ -483,6 +583,32 @@ describe('ExchangeRateService', () => {
           rate: latestRate,
         });
       });
+
+      it('healthcheck를 update한다', async () => {
+        // Arrange
+        exchangeRateRedisService.getLatestRate.mockResolvedValue([
+          `${latestRate}`,
+          `${latestTimestamp}`,
+        ]);
+        const helthCheckSpy = jest.spyOn(
+          exchangeRateRedisService,
+          'updateHealthCheck',
+        );
+
+        // Act
+        await exchangeRateService.processLatestRateFromWS(
+          baseCurrency,
+          currencyCode,
+          latestRate,
+          latestTimestamp,
+        );
+
+        // Assert
+        expect(helthCheckSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('해당 통화쌍에 대한 hash-set데이터가 존재할 경우', () => {
       describe('날짜가 바뀌지 않은 경우 (같은 일(day)의 소켓 데이터인 경우)', () => {
         beforeEach(() => {
           dateUtilService.isBefore.mockReturnValue(false);

--- a/src/modules/exchange-rate/__test__/unit/exchange-rate.service.spec.ts
+++ b/src/modules/exchange-rate/__test__/unit/exchange-rate.service.spec.ts
@@ -207,7 +207,7 @@ describe('ExchangeRateService', () => {
         // Arrange
         const baseCurrency = 'KRW';
         const recentUpdateCacheDate = new Date(); // 캐시된 최신 데이터
-        exchangeRateRedisService.latestRateHealthCheck.mockResolvedValue(
+        exchangeRateRedisService.getLatestRateHealthCheck.mockResolvedValue(
           recentUpdateCacheDate,
         );
         exchangeRateRedisService.getLatestRate.mockResolvedValue([
@@ -235,7 +235,7 @@ describe('ExchangeRateService', () => {
         // Arrange
         const baseCurrency = 'KRW';
         const recentUpdateCacheDate = new Date(Date.now() - 15000); // 15초 전 캐시된 데이터
-        exchangeRateRedisService.latestRateHealthCheck.mockResolvedValue(
+        exchangeRateRedisService.getLatestRateHealthCheck.mockResolvedValue(
           recentUpdateCacheDate,
         );
         exchangeRateRedisService.getLatestRate.mockResolvedValue([

--- a/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
@@ -68,7 +68,7 @@ export class ExchangeRateRedisService {
     this.logger.debug(`update latest-rate healthcheck!!: ${baseCurrency}`);
   }
 
-  async latestRateHealthCheck(baseCurrency: string): Promise<Date | null> {
+  async getLatestRateHealthCheck(baseCurrency: string): Promise<Date | null> {
     const key = `${this.healthCheckey}${baseCurrency}`;
     const result = await this.redisService.get<Date>(key);
 

--- a/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
@@ -61,7 +61,7 @@ export class ExchangeRateRedisService {
   }
 
   async updateHealthCheck(baseCurrency: string): Promise<void> {
-    const key = `${this.healthCheckey}${baseCurrency}`;
+    const key = `${this.healthCheckey}:${baseCurrency}`;
 
     await this.redisService.set(key, new Date().toISOString());
 

--- a/src/modules/exchange-rate/services/exchange-rate.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate.service.ts
@@ -14,7 +14,6 @@ import {
 import { DateUtilService } from '../../../common/utils/date-util/date-util.service';
 import { ExchangeRateRawRepository } from '../repositories/exchange-rate-raw.repository';
 import { IExchangeRateDaily } from '../interfaces/exchange-rate-daily.interface';
-import { IExchangeRateExternalAPI } from '../../../infrastructure/externals/exchange-rates/interfaces/exchange-rate-api.interface';
 import { getCurrencyNameInKorean } from '../constants/symbol-kr.mapper';
 import { ExchangeRateRedisService } from './exchange-rate-redis.service';
 
@@ -381,6 +380,7 @@ export class ExchangeRateService {
       }
     }
 
+    // 헬스체크 업데이트
     await this.exchangeRateRedisService.updateHealthCheck(baseCurrency);
     // 레코드 삽입 (default-postgres)
     await this.exchangeRateRawRepository.createExchangeRate({

--- a/src/modules/exchange-rate/services/exchange-rate.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate.service.ts
@@ -317,11 +317,14 @@ export class ExchangeRateService {
       }
     }
 
+    await this.exchangeRateRedisService.updateHealthCheck(baseCurrency);
     // 레코드 삽입 (default-postgres)
-    return await this.exchangeRateRawRepository.createExchangeRate({
+    await this.exchangeRateRawRepository.createExchangeRate({
       baseCurrency: baseCurrency,
       currencyCode: currencyCode,
       rate: latestRateRound,
     });
+
+    return;
   }
 }

--- a/src/modules/exchange-rate/services/exchange-rate.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate.service.ts
@@ -22,6 +22,7 @@ import { ExchangeRateRedisService } from './exchange-rate-redis.service';
 export class ExchangeRateService {
   private readonly logger = new Logger(ExchangeRateService.name);
   private readonly supportCurrencyList = supportCurrencyList;
+  private readonly latestRatethreshold = 10000; // 임계값 10s
 
   constructor(
     @Inject('LATEST_EXCHANGE_RATE_API')
@@ -41,6 +42,53 @@ export class ExchangeRateService {
       ? input.currencyCodes
       : this.supportCurrencyList;
     const today = new Date();
+    const fallbackRates: Record<
+      string,
+      Pick<RateDetail, 'rate' | 'dayChange' | 'dayChangePercent' | 'timestamp'>
+    > = {};
+
+    // 여기에 latestRate, fluctuationRates 캐시 조회
+    const isCacheHit =
+      await this.exchangeRateRedisService.latestRateHealthCheck(
+        input.baseCurrency,
+      );
+
+    if (
+      isCacheHit &&
+      isCacheHit.getTime() > Date.now() - this.latestRatethreshold
+    ) {
+      this.logger.debug('latest-rate cache hit!!');
+      const cachedRates: Record<
+        string,
+        Pick<
+          RateDetail,
+          'rate' | 'dayChange' | 'dayChangePercent' | 'timestamp'
+        >
+      > = {};
+
+      for (const code of targetCodes) {
+        const [change, changePct, rate, timestamp] =
+          await this.exchangeRateRedisService.getLatestRate(
+            input.baseCurrency,
+            code,
+          );
+
+        // 캐시 히트 시 무조건 4개 캐시데이터 보장
+        cachedRates[code] = {
+          rate: Number(rate),
+          dayChange: Number(change),
+          dayChangePercent: Number(changePct),
+          timestamp: new Date(Number(timestamp)),
+        };
+      }
+
+      return {
+        baseCurrency: input.baseCurrency,
+        rates: this.combinateLatestRates(cachedRates),
+      };
+    }
+
+    this.logger.debug('cache missed!!');
     const [latestRates, fluctuationRates] = await Promise.all([
       this.latestExchangeRateAPI.getLatestRates(
         input.baseCurrency,
@@ -53,30 +101,46 @@ export class ExchangeRateService {
         targetCodes,
       ),
     ]);
-
-    const rateResponse = Object.keys(latestRates.rates).reduce<
-      Record<string, RateDetail>
-    >((acc, currency) => {
-      const rate = latestRates[currency];
-      const inverseRate = parseFloat((1 / rate).toFixed(6));
-      const fluctuation = fluctuationRates.rates[currency];
-
-      acc[currency] = {
-        name: getCurrencyNameInKorean(currency),
-        rate,
-        inverseRate,
-        dayChange: fluctuation.change,
-        dayChangePercent: fluctuation.changePct,
+    targetCodes.forEach((code) => {
+      fallbackRates[code] = {
+        rate: latestRates.rates[code],
+        dayChange: fluctuationRates.rates[code].change,
+        dayChangePercent: fluctuationRates.rates[code].changePct,
         timestamp: new Date(),
       };
-
-      return acc;
-    }, {});
+    });
 
     return {
       baseCurrency: latestRates.baseCurrency,
-      rates: rateResponse,
+      rates: this.combinateLatestRates(fallbackRates),
     };
+  }
+
+  /**
+   * Gernerate daily data by combining recent currency-rate and fluctuation rate
+   */
+  private combinateLatestRates(
+    rates: Record<
+      string,
+      Pick<RateDetail, 'rate' | 'dayChange' | 'dayChangePercent' | 'timestamp'>
+    >,
+  ): Record<string, RateDetail> {
+    return Object.keys(rates).reduce<Record<string, RateDetail>>(
+      (acc, currency) => {
+        const data = rates[currency];
+
+        acc[currency] = {
+          name: getCurrencyNameInKorean(currency),
+          rate: data.rate,
+          dayChange: data.dayChange,
+          dayChangePercent: data.dayChangePercent,
+          inverseRate: parseFloat((1 / data.rate).toFixed(6)),
+          timestamp: data.timestamp,
+        };
+        return acc;
+      },
+      {},
+    );
   }
 
   /**

--- a/src/modules/exchange-rate/services/exchange-rate.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate.service.ts
@@ -48,7 +48,7 @@ export class ExchangeRateService {
 
     // 여기에 latestRate, fluctuationRates 캐시 조회
     const isCacheHit =
-      await this.exchangeRateRedisService.latestRateHealthCheck(
+      await this.exchangeRateRedisService.getLatestRateHealthCheck(
         input.baseCurrency,
       );
 


### PR DESCRIPTION
## 1. Add caching
- add cacing layer when called `GET /api/exchange-rate/current?baseCurrency= ??`
- separate `combinateLatestRates` method to branch out caching logic
- check healthcheck before call external API

## 2. Add Healthcheck data into redis
- add `exchange-rate:healthcheck:{basecurrency}` to detect LatestRateExchangeRate rate data collection from external API

## 3. Add tests
- add integration tests `exchange-rate-redis.spec.ts` [Integration]
- add integration tests `exchange-rate-service.spec.ts` [Unit]