### PR TITLE
Feat: add conditionals depending on market status when using cache

### DIFF
--- a/src/modules/exchange-rate/__test__/fixture/exchange-rate-fixture.ts
+++ b/src/modules/exchange-rate/__test__/fixture/exchange-rate-fixture.ts
@@ -41,8 +41,8 @@ export class ExchangeRateFixture {
           endRate: 1,
           highRate: 1,
           lowRate: 1,
-          change: 0,
-          changePct: 0,
+          change: 12,
+          changePct: 1.3,
         },
       ]),
     );


### PR DESCRIPTION
### baseCurrency가 KRW가 아닌 경우 (redis데이터 역산) 시장 오픈 유무에 따른 외부 API 캐싱 조건 추가
- 시장이 닫혔을 경우: redis에 마지막 저장된 (UTC 금요일 21:00) 환율 데이터를 기준으로 역산, change, changePercent = 0

### fallback시 (fetch latetRate, fluctuationRate from external API) 퍼포먼스 로그 추가

### 위 기능에 해당하는 unit테스트 추가
