### PR TITLE
refactor: 최신환율 수집 전략 변경

### DIFF
--- a/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
@@ -27,7 +27,7 @@ export class ExchangeRateRedisService {
   }
 
   async setLatestRate(
-    baseCurrency: string,
+    baseCurrency: 'KRW', // 휴먼에러 방지
     currencyCode: string,
     fields: IRedisSchema.ILatestRateHash,
   ): Promise<void> {
@@ -63,7 +63,7 @@ export class ExchangeRateRedisService {
   async updateHealthCheck(baseCurrency: string): Promise<void> {
     const key = `${this.healthCheckey}:${baseCurrency}`;
 
-    await this.redisService.set(key, new Date().toISOString());
+    await this.redisService.set(key, new Date().toISOString(), 30);
 
     this.logger.debug(`update latest-rate healthcheck!!: ${baseCurrency}`);
   }


### PR DESCRIPTION
# 환율데이터 저장전략 변경 및 구조 전면 개선
## 서버는 무조건 KRW만 수집 & baseCurrency도 KRW 고정

- Websocket연결 레벨에서 시장 열림 여부 확인
- `handleLatestRateUpdate`메서드에서 시장 열림 여부 확인 로직 전면 제거
- 해당 메서드에서 최초수집 시 fluctuation api 호출해서 장애 시 데이터 보강하는 로직 추가
- 날짜 변경 감지 후 변동률 초기화 조건문 최적화 (ealry return)
- 헬스체크 업데이트를 `handleLatestRateEvent` <- 해당 리스너로 이동
- 소켓 수신 데이터마다 exchnagerate_history(RDB) 무조건 삽입
- `handleLatestRateUpdate` 비즈니스 로직 단순화

## 해당하는 단위 테스트 추가

## TODO
- Subscriber, Listener 테스트 (통합, 단위 미정)