### PR TITLE
Change baseCurrency to cover KRW our application

### DIFF
--- a/src/common/utils/date-util/date-util.service.ts
+++ b/src/common/utils/date-util/date-util.service.ts
@@ -61,4 +61,30 @@ export class DateUtilService {
 
     return day >= 1 && day <= 5; // 월(1) ~ 금(5)만 열림
   }
+
+  /**
+   * 마지막으로 시장이 열렸던 날짜 반환 (UTC 기준)
+   * - 월요일이면 금요일 (3일 전)
+   * - 일요일이면 금요일 (2일 전)
+   * - 토요일이면 금요일 (1일 전)
+   * - 나머지는 하루 전
+   */
+  getLastMarketDay(): Date {
+    const now = new Date();
+    const day = now.getUTCDay(); // 0 = Sunday, 6 = Saturday
+
+    let offset = 1;
+    if (day === 0) {
+      // Sunday
+      offset = 2;
+    } else if (day === 1) {
+      // Monday
+      offset = 3;
+    }
+
+    const lastMarketDay = new Date(now);
+    lastMarketDay.setUTCDate(now.getUTCDate() - offset);
+
+    return dayjs(dayjs(lastMarketDay).format('YYYY-MM-DD')).toDate();
+  }
 }

--- a/src/infrastructure/externals/exchange-rates/currencylayer/currencylayer.service.ts
+++ b/src/infrastructure/externals/exchange-rates/currencylayer/currencylayer.service.ts
@@ -79,7 +79,10 @@ export class CurrencyLayerService implements IFluctuationExchangeRateApi {
     baseCurrency = 'EUR',
     currencyCodes: string[] = [],
   ): Promise<IExchangeRateExternalAPI.IFluctuationResponse> {
-    const currencies = currencyCodes.join(',');
+    const currencies = currencyCodes
+      .filter((code) => code !== baseCurrency)
+      .join(',');
+
     const [startDateString, endDateString] = this.formatDateToString(
       startDate,
       endDate,
@@ -92,6 +95,7 @@ export class CurrencyLayerService implements IFluctuationExchangeRateApi {
       );
     if (!data.success) {
       this.logger.error('CurrencyLayer Error: ', data);
+
       throw new Error(`CurrencyLayer Error: ${JSON.stringify(data)}`);
     }
     const fluctuationRates = this.parseFluctuationQuotes(

--- a/src/modules/exchange-rate/dto/exchange-rates.dto.ts
+++ b/src/modules/exchange-rate/dto/exchange-rates.dto.ts
@@ -1,8 +1,7 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, Matches } from 'class-validator';
 import { IsValidCurrencyCode } from '../../../common/decorators/validations/is-valid-currency.validator';
-import { BaseOffsetDto } from '../../../common/dto/pagination/base-offset.dto';
 
 export class CurrentExchangeRateReqDto {
   /**
@@ -11,7 +10,7 @@ export class CurrentExchangeRateReqDto {
    * @example EUR
    */
   @IsNotEmpty()
-  @IsValidCurrencyCode()
+  @Matches(/^KRW$/, { message: 'baseCurrency is only can be KRW.' })
   baseCurrency: string;
 
   /**


### PR DESCRIPTION
## BaseCurrency KRW 고정 (역산 로직 삭제)

- `getCurrencyExchangeRates` 에서 baseCurrency(자기자신 환율 1 처리) 관련 로직 제거 (외부 api 구현부로 책임 위임)
- baseCurrency가 KRW고정됨에 따라, 역산 처리 로직 삭제.

- baseCurrency가 'KRW'가 아닌 경우 따로 역산하지 않고 단순히 제외

## cache miss & 주말인경우, 폴백(snapshot)로직 추가.
- fallback snapshot 생성 로직 간소화

## 해당 변경사항에 대한 유닛테스트 추가

## TODO
- 시장 마감 직전 해당 날짜 snapshot 생성 스케줄러 통합 테스트 or 유닛 테스트 작성 예정
- 추후 fallback snapshot 없을 때의 상세 에러케이스 추가 예정

Closes #53 