### PR TITLE
refactor: 외부 환율 API/WS 의존성 기반 서비스 재설계 및 모듈 분리

### DIFF
--- a/src/infrastructure/externals/exchange-rates/coin-api/coin-api-ws.service.ts
+++ b/src/infrastructure/externals/exchange-rates/coin-api/coin-api-ws.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IExchangeRateWebSocketService } from '../interfaces/exchange-rate-websocket.interface';
+import { WebSocket } from 'ws';
+import { supportCurrencyList } from '../../../../modules/exchange-rate/constants/support-currency.constant';
+import { ExternalWebSocketGateWay } from '../../external-websocket.gateway';
+import { ConfigService } from '@nestjs/config';
+import { AppConfig } from '../../../config/config.type';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CoinApiWebSocket } from './interfaces/coin-api-websocket.interface';
+import { LatestRateEvent } from '../../../events/exchange-rate/latest-rate.event';
+
+@Injectable()
+export class CoinApiWebSocketService implements IExchangeRateWebSocketService {
+  private ws: WebSocket;
+  private readonly conApiUrl: string;
+  private readonly defaultBaseCurrency: string = 'KRW';
+  private readonly majorCurrencyCode: string[] = supportCurrencyList;
+  private readonly logger: Logger = new Logger(ExternalWebSocketGateWay.name);
+
+  constructor(
+    private readonly configService: ConfigService<AppConfig, true>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
+    this.conApiUrl = this.configService.get('coinApi.baseUrl', {
+      infer: true,
+    });
+  }
+
+  connect(): void {
+    this.ws = new WebSocket(this.conApiUrl, {
+      headers: {
+        authorization: this.configService.get('coinApi.apiKey', {
+          infer: true,
+        }),
+      },
+    });
+
+    this.ws.on('open', () => {
+      this.logger.debug('@@coinapi websocket connected@@');
+
+      const currencyPairs = this.majorCurrencyCode
+        .filter((currency) => currency !== this.defaultBaseCurrency) // KRW/KRW 방지
+        .map((currency) => `${this.defaultBaseCurrency}/${currency}`);
+
+      this.ws.send(
+        JSON.stringify({
+          type: 'hello',
+          heartbeat: false,
+          subscribe_filter_asset_id: currencyPairs,
+          subscribe_update_limit_ms_exrate: 5000,
+        }),
+      );
+    });
+
+    this.ws.on('message', async (data) => {
+      const priceData: CoinApiWebSocket.ExchangeRateMessage = JSON.parse(
+        data.toString(),
+      );
+
+      if (
+        priceData.type === 'exrate' &&
+        priceData.asset_id_base === this.defaultBaseCurrency
+      ) {
+        this.eventEmitter.emit(
+          LatestRateEvent.eventName,
+          new LatestRateEvent(
+            new Date(priceData.time).getTime(),
+            priceData.asset_id_base,
+            priceData.asset_id_quote,
+            priceData.rate,
+          ),
+        );
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.logger.debug('WebSocket release');
+      setTimeout(() => this.connect(), 5000); // 연결 끊겼을시 재연결 로직
+    });
+
+    this.ws.on('error', (error) => {
+      this.logger.error('WebSocket error', error);
+    });
+  }
+
+  disconnect(): void {
+    this.ws?.close();
+    this.logger.log('Websocket connection closed');
+  }
+}

--- a/src/infrastructure/externals/exchange-rates/coin-api/coin-api.service.ts
+++ b/src/infrastructure/externals/exchange-rates/coin-api/coin-api.service.ts
@@ -7,16 +7,12 @@ import {
   IFluctuationExchangeRateApi,
   ILatestExchangeRateApi,
 } from '../interfaces/exchange-rate-rest-api.interface';
-import { IExchangeRateWebSocketService } from '../interfaces/exchange-rate-websocket.interface';
 import { ICoinApiResponse } from './interfaces/coin-api-response.interface';
 import { supportCurrencyList } from '../../../../modules/exchange-rate/constants/support-currency.constant';
 
 @Injectable()
 export class CoinApiService
-  implements
-    ILatestExchangeRateApi,
-    IFluctuationExchangeRateApi,
-    IExchangeRateWebSocketService
+  implements ILatestExchangeRateApi, IFluctuationExchangeRateApi
 {
   private readonly apiUrl: string;
   private readonly logger = new Logger(CoinApiService.name);
@@ -52,7 +48,7 @@ export class CoinApiService
       rates: data.rates.reduce((acc, rateInfo) => {
         acc[rateInfo.asset_id_quote] = rateInfo.rate;
         return acc;
-      }, {} as any),
+      }, {}),
     };
   }
 

--- a/src/infrastructure/externals/exchange-rates/coin-api/mock/coin-api-socket-mock.service.ts
+++ b/src/infrastructure/externals/exchange-rates/coin-api/mock/coin-api-socket-mock.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { IExchangeRateWebSocketService } from '../../interfaces/exchange-rate-websocket.interface';
+import { interval, Subscription } from 'rxjs';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { supportCurrencyList } from '../../../../../modules/exchange-rate/constants/support-currency.constant';
+import { LatestRateEvent } from '../../../../events/exchange-rate/latest-rate.event';
+
+@Injectable()
+export class CoinApiSocketMockService implements IExchangeRateWebSocketService {
+  private subscription: Subscription | null = null;
+  private readonly baseCurrency = 'KRW';
+  private readonly initialRates: Record<string, number> = {};
+  private readonly fluctuationRange = 0.005; // +-0.5% 정도 변동
+
+  constructor(private readonly eventEmitter: EventEmitter2) {
+    // 초기 레이트 셋팅 (대충 임의로 0.001 ~ 0.01 사이로 세팅)
+    supportCurrencyList.forEach((currency) => {
+      if (currency !== this.baseCurrency) {
+        this.initialRates[currency] = 0.001 + Math.random() * 0.009;
+      }
+    });
+  }
+
+  /**
+   * 테스트용 환율 데이터 생성 및 이벤트 발생 메서드
+   * 실제 웹소켓 연결 없이 랜덤 환율 데이터를 생성하여 이벤트를 발생시킴
+   */
+  connect(): void {
+    // 5초마다 환율 변동 시뮬레이션
+    this.subscription = interval(5000).subscribe(() => {
+      const now = Date.now();
+      for (const [currencyCode, baseRate] of Object.entries(
+        this.initialRates,
+      )) {
+        // 약간의 변동을 줌
+        const fluctuation =
+          baseRate *
+          (Math.random() * this.fluctuationRange * 2 - this.fluctuationRange);
+        const newRate = baseRate + fluctuation;
+        // 저장
+        this.initialRates[currencyCode] = newRate;
+        // 이벤트 발생
+        this.eventEmitter.emit(
+          LatestRateEvent.eventName,
+          new LatestRateEvent(now, this.baseCurrency, currencyCode, newRate),
+        );
+      }
+    });
+  }
+  disconnect(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+  }
+}

--- a/src/infrastructure/externals/exchange-rates/interfaces/exchange-rate-websocket.interface.ts
+++ b/src/infrastructure/externals/exchange-rates/interfaces/exchange-rate-websocket.interface.ts
@@ -1,1 +1,4 @@
-export interface IExchangeRateWebSocketService {}
+export interface IExchangeRateWebSocketService {
+  connect(): void;
+  disconnect(): void;
+}

--- a/src/infrastructure/externals/exchange-rates/market-status-scheduler.ts
+++ b/src/infrastructure/externals/exchange-rates/market-status-scheduler.ts
@@ -1,25 +1,27 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { ExternalWebSocketGateWay } from '../external-websocket.gateway';
+import { IExchangeRateWebSocketService } from './interfaces/exchange-rate-websocket.interface';
 
 @Injectable()
 export class MarketStatusScheduler {
   private readonly logger = new Logger(MarketStatusScheduler.name);
   constructor(
-    private readonly externalWebsocketGateWay: ExternalWebSocketGateWay,
+    @Inject('WEBSOCKET_IMPL')
+    private readonly collectLatestRateSocket: IExchangeRateWebSocketService,
   ) {}
 
   // 매주 일요일 21시 정각 (UTC)
   @Cron('0 21 * * 0')
   handleMarketOpen() {
-    this.externalWebsocketGateWay.testConnectLatestRateSocket();
+    // this.externalWebsocketGateWay.testConnectLatestRateSocketㅇ();
+    this.collectLatestRateSocket.connect();
     this.logger.debug('시장 개장시간이라 latestRate 소켓연결을 시작합니다.');
   }
 
   //   매주 금요일 21시 정각
   @Cron('0 21 * * 5')
   handleMarketClose() {
-    this.externalWebsocketGateWay.disconnectLatestRateSocket();
+    this.collectLatestRateSocket.disconnect();
     this.logger.debug('시장 마감시간이라 latestRate 소켓연결을 해제합니다.');
   }
 }

--- a/src/infrastructure/externals/external-websocket.gateway.ts
+++ b/src/infrastructure/externals/external-websocket.gateway.ts
@@ -1,130 +1,23 @@
-import WebSocket from 'ws';
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { AppConfig } from '../config/config.type';
-import { EventEmitter2 } from '@nestjs/event-emitter';
-import { supportCurrencyList } from '../../modules/exchange-rate/constants/support-currency.constant';
-import { CoinApiWebSocket } from './exchange-rates/coin-api/interfaces/coin-api-websocket.interface';
-import { interval, Subscription } from 'rxjs';
-import { LatestRateEvent } from '../events/exchange-rate/latest-rate.event';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { IExchangeRateWebSocketService } from './exchange-rates/interfaces/exchange-rate-websocket.interface';
 import { DateUtilService } from '../../common/utils/date-util/date-util.service';
 
 @Injectable()
 export class ExternalWebSocketGateWay implements OnModuleInit {
-  private ws: WebSocket;
-  private readonly websocketUrl: string;
-  private readonly defaultBaseCurrency: string = 'KRW';
-  private readonly majorCurrencyCode: string[] = supportCurrencyList;
   private readonly logger: Logger = new Logger(ExternalWebSocketGateWay.name);
-  private intervalSubscription: Subscription;
 
   constructor(
-    private readonly configService: ConfigService<AppConfig, true>,
-    private readonly eventEmitter: EventEmitter2,
+    @Inject('WEBSOCKET_IMPL')
+    private readonly collectLatestRateSocket: IExchangeRateWebSocketService,
     private readonly dateUtilService: DateUtilService,
-  ) {
-    this.websocketUrl = this.configService.get('coinApi.baseUrl', {
-      infer: true,
-    });
-  }
+  ) {}
 
   onModuleInit() {
     if (this.dateUtilService.isMarketOpen()) {
-      this.connectLatestRateSocket();
+      this.logger.verbose('[개장]: 실시간 환율정보 수집');
+      this.collectLatestRateSocket.connect();
     } else {
-      this.disconnectLatestRateSocket();
+      this.logger.verbose('[휴장]: 실시간 환율정보 수집 연결하지 않음');
     }
-  }
-
-  /**
-   * 테스트용 환율 데이터 생성 및 이벤트 발생 메서드
-   * 실제 웹소켓 연결 없이 랜덤 환율 데이터를 생성하여 이벤트를 발생시킴
-   */
-  testConnectLatestRateSocket() {
-    this.logger.debug('테스트 웹소켓 시뮬레이션 시작 (KRW/EUR)');
-
-    // 기준 환율 (KRW/EUR)
-    const baseRate = 0.06675258830083569;
-
-    // 5초마다 데이터 생성 및 이벤트 발생
-    this.intervalSubscription = interval(5000).subscribe(() => {
-      // 현재 환율 = 기준 환율 +/- 최대 1% 변동
-      const fluctuation = baseRate * (Math.random() * 0.02 - 0.01);
-      const rate = baseRate + fluctuation;
-
-      // 타임스탬프는 현재 시간으로
-      const timestamp = Date.now();
-
-      this.logger.debug(
-        `테스트 환율 이벤트 발생: KRW/EUR = ${rate.toFixed(4)}`,
-      );
-
-      // 이벤트 발생
-      this.eventEmitter.emit(
-        LatestRateEvent.eventName,
-        new LatestRateEvent(timestamp, 'KRW', 'EUR', rate),
-      );
-    });
-  }
-
-  connectLatestRateSocket() {
-    this.ws = new WebSocket(this.websocketUrl, {
-      headers: {
-        authorization: this.configService.get('coinApi.apiKey', {
-          infer: true,
-        }),
-      },
-    });
-
-    this.ws.on('open', () => {
-      this.logger.debug('@@coinapi websocket connected@@');
-
-      const currencyPairs = this.majorCurrencyCode
-        .filter((currency) => currency !== this.defaultBaseCurrency) // KRW/KRW 방지
-        .map((currency) => `${this.defaultBaseCurrency}/${currency}`);
-      this.ws.send(
-        JSON.stringify({
-          type: 'hello',
-          heartbeat: false,
-          subscribe_filter_asset_id: currencyPairs,
-          subscribe_update_limit_ms_exrate: 5000,
-        }),
-      );
-    });
-
-    this.ws.on('message', async (data) => {
-      const priceData: CoinApiWebSocket.ExchangeRateMessage = JSON.parse(
-        data.toString(),
-      );
-
-      if (
-        priceData.type === 'exrate' &&
-        priceData.asset_id_base === this.defaultBaseCurrency
-      ) {
-        this.eventEmitter.emit(
-          LatestRateEvent.eventName,
-          new LatestRateEvent(
-            new Date(priceData.time).getTime(),
-            priceData.asset_id_base,
-            priceData.asset_id_quote,
-            priceData.rate,
-          ),
-        );
-      }
-    });
-
-    this.ws.on('close', () => {
-      this.logger.debug('WebSocket release');
-      setTimeout(() => this.connectLatestRateSocket(), 5000);
-    });
-
-    this.ws.on('error', (error) => {
-      this.logger.error('WebSocket error', error);
-    });
-  }
-
-  disconnectLatestRateSocket() {
-    this.ws?.close();
-    this.logger.log('Websocket connection closed');
   }
 }

--- a/src/infrastructure/externals/external.module.ts
+++ b/src/infrastructure/externals/external.module.ts
@@ -3,36 +3,35 @@ import { CoinApiModule } from './exchange-rates/coin-api/coin-api.module';
 import { ExternalWebSocketGateWay } from './external-websocket.gateway';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { FrankFurterService } from './exchange-rates/frankfurter/frankfurter.service';
-import { FixerService } from './exchange-rates/fixer/fixer.service';
-import { CoinApiService } from './exchange-rates/coin-api/coin-api.service';
-import { CurrencyLayerService } from './exchange-rates/currencylayer/currencylayer.service';
+import { MockCurrencyLayerService } from './exchange-rates/currencylayer/mock/currencylayer-mock.service';
+import { CoinApiSocketMockService } from './exchange-rates/coin-api/mock/coin-api-socket-mock.service';
 
 @Module({
   imports: [CoinApiModule.forRootAsync(), EventEmitterModule.forRoot()],
   providers: [
     {
       provide: 'LATEST_EXCHANGE_RATE_API',
-      useClass: CoinApiService,
+      useClass: MockCurrencyLayerService,
     },
     {
-      provide: 'CURRENCYLAYER_FLUCTUATION_RATE_API',
-      useClass: CurrencyLayerService,
+      provide: 'FLUCTUATION_RATE_API',
+      useClass: MockCurrencyLayerService,
     },
     {
       provide: 'TIMESERIES_RATE_API',
       useClass: FrankFurterService,
     },
     {
-      provide: 'COINAPI_FLUCTUATION_RATE_API',
-      useClass: CoinApiService,
+      provide: 'WEBSOCKET_IMPL',
+      useClass: CoinApiSocketMockService,
     },
     ExternalWebSocketGateWay,
   ],
   exports: [
     'LATEST_EXCHANGE_RATE_API',
-    'CURRENCYLAYER_FLUCTUATION_RATE_API',
-    'COINAPI_FLUCTUATION_RATE_API',
+    'FLUCTUATION_RATE_API',
     'TIMESERIES_RATE_API',
+    'WEBSOCKET_IMPL',
   ],
 })
 export class ExternalAPIModule {}

--- a/src/modules/exchange-rate/__test__/integration/exchange-rate.controller.spec.ts
+++ b/src/modules/exchange-rate/__test__/integration/exchange-rate.controller.spec.ts
@@ -9,13 +9,18 @@ import { TestIntegrateModules } from '../../../../../test/integration/utils/inte
 import { ExchangeRateService } from '../../services/exchange-rate.service';
 import { ExchangeRateRawRepository } from '../../repositories/exchange-rate-raw.repository';
 import { ExchangeRateRedisService } from '../../services/exchange-rate-redis.service';
+import { DateUtilModule } from '../../../../common/utils/date-util/date-util.module';
 
 describe('ExchangeRateController', () => {
   let controller: ExchangeRateController;
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [...TestIntegrateModules.create(), ExternalAPIModule],
+      imports: [
+        ...TestIntegrateModules.create(),
+        ExternalAPIModule,
+        DateUtilModule,
+      ],
       controllers: [ExchangeRateController],
       providers: [
         ExchangeRateService,

--- a/src/modules/exchange-rate/listeners/latest-rate.listener.ts
+++ b/src/modules/exchange-rate/listeners/latest-rate.listener.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ExchangeRateService } from '../services/exchange-rate.service';
 import { LatestRateEvent } from '../../../infrastructure/events/exchange-rate/latest-rate.event';
@@ -6,6 +6,8 @@ import { ExchangeRateRedisService } from '../services/exchange-rate-redis.servic
 
 @Injectable()
 export class LatestRateListener {
+  private readonly logger: Logger = new Logger(LatestRateListener.name);
+
   constructor(
     private readonly exchangeRateRedisService: ExchangeRateRedisService,
     private readonly exchangeRateService: ExchangeRateService,
@@ -29,6 +31,10 @@ export class LatestRateListener {
       event.currencyCode,
       event.rate,
       event.timestamp,
+    );
+
+    this.logger.debug(
+      `update latest-rate healthcheck!!: ${event.baseCurrency}/${event.currencyCode}`,
     );
   }
 }

--- a/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
+++ b/src/modules/exchange-rate/services/exchange-rate-redis.service.ts
@@ -64,8 +64,6 @@ export class ExchangeRateRedisService {
     const key = `${this.healthCheckey}:${baseCurrency}`;
 
     await this.redisService.set(key, new Date().toISOString(), 30);
-
-    this.logger.debug(`update latest-rate healthcheck!!: ${baseCurrency}`);
   }
 
   async getLatestRateHealthCheck(baseCurrency: string): Promise<Date | null> {


### PR DESCRIPTION
### 1. 외부 환율 API의존성 주입 방식 개편
- 기존: `CURRENCYLAYER_FLUCTUATION_API`, `COINAPI_FLUCTUATION_RATE_API` 등 **구현체 기반 명명**
- 변경: `EXCHANGE_RATE_LATEST_API`, `EXCHANGE_RATE_FLUCTUATION_API`, `EXCHANGE_RATE_TIMESERIES_API` 등 **기능 기반 명명**
- 서비스는 기능 인터페이스만 알고, 구현체는 외부 모듈에서 주입

### 2. 외부 WS 인터페이스 정의 및 이에따른 의존성 분리 (API 무료크레딧 다씀ㅠㅠ)
- `IExchangeRateWebSocketService` 인터페이스 정의
- 실서비스: `CoinApiWebSocketService`
- 테스트용: `CoinApiSocketMockService`
- `ExternalWebSocketGateway`는 **구현체에 의존하지 않고**, 오직 인터페이스만 통해 connect/disconnect 수행

### 3. `ExternalAPIModule` 프로바이더 토큰 정리
- 외부 API/소켓 관련 모든 의존성을 이곳에서 관리