### PR TITLE
feat: implement FCM push notification and device token management

### DIFF
--- a/src/modules/fcm/__test__/unit/fcm.service.spec.ts
+++ b/src/modules/fcm/__test__/unit/fcm.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { app, messaging } from 'firebase-admin';
+import { FcmService } from '../../fcm.service';
+import { UsersDeviceRepository } from '../../../users/repositories/users-device.repository';
+import { UserDeviceEntity } from '../../../users/entities/user-device.entity';
+import typia from 'typia';
+import { MulticastMessage } from 'firebase-admin/lib/messaging/messaging-api';
+import {
+  NOTIFICATION_TYPES,
+  NotificationDataMap,
+  NotificationType,
+} from '../../../notifications/types/notification.type';
+
+describe('FcmService [unit]', () => {
+  let fcmService: FcmService;
+  let firebaseMock: MockProxy<app.App>;
+  let usersDeviceRepository: MockProxy<UsersDeviceRepository>;
+
+  beforeEach(async () => {
+    firebaseMock = mock<app.App>();
+    usersDeviceRepository = mock<UsersDeviceRepository>();
+
+    const module = await Test.createTestingModule({
+      providers: [
+        FcmService,
+        {
+          provide: 'FCM_ADMIN',
+          useValue: firebaseMock,
+        },
+        {
+          provide: UsersDeviceRepository,
+          useValue: usersDeviceRepository,
+        },
+      ],
+    }).compile();
+
+    fcmService = module.get(FcmService);
+  });
+
+  it('should be definded', () => {
+    expect(fcmService).toBeDefined();
+  });
+
+  describe('sendNotificationToDevice', () => {
+    it('should send FCM with correct targetPrice payload', async () => {
+      // Arrange
+      const userIdx = 1;
+      const mockTokens = ['token_1', 'token_2'];
+      usersDeviceRepository.findTokensByUser.mockResolvedValue(
+        mockTokens.map((e) => ({ deviceToken: e })) as UserDeviceEntity[],
+      );
+      const notificationPayload = {
+        notificationType: NOTIFICATION_TYPES.TARGET_PRICE,
+        notification: {
+          title: 'targetPrice notification title',
+          body: 'targetPrice notification body',
+        },
+        data: {
+          baseCurrency: 'KRW',
+          currencyCode: 'EUR',
+          targetPrice: 1500,
+        },
+      };
+
+      // Act
+      const sendEachMock = jest.fn().mockResolvedValue({
+        successCount: 2,
+        failureCount: 0,
+        responses: [],
+      });
+
+      (firebaseMock.messaging as () => messaging.Messaging) = () =>
+        ({ sendEachForMulticast: sendEachMock }) as any;
+
+      // Assert
+      await fcmService.sendNotificationToDevice<'TARGET_PRICE'>(userIdx, {
+        data: notificationPayload.data,
+        notification: notificationPayload.notification,
+        notificationType: notificationPayload.notificationType,
+      });
+
+      expect(sendEachMock).toHaveBeenCalledWith({
+        data: {
+          type: notificationPayload.notificationType,
+          payload: JSON.stringify(notificationPayload.data),
+        },
+        notification: {
+          ...notificationPayload.notification,
+        },
+        tokens: mockTokens,
+      });
+    });
+
+    it.todo('should log if tokens are not exist');
+    it.todo('should log warnings for failed tokens');
+    it.todo('should throw error if firebase throws');
+  });
+});

--- a/src/modules/fcm/fcm.module.ts
+++ b/src/modules/fcm/fcm.module.ts
@@ -3,9 +3,10 @@ import { ConfigService } from '@nestjs/config';
 import * as fcmAdmin from 'firebase-admin';
 import { AppConfig } from '../../infrastructure/config/config.type';
 import { FcmService } from './fcm.service';
-import { UsersRepository } from '../users/repositories/users.repository';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [UsersModule],
   providers: [
     FcmService,
     {
@@ -25,7 +26,6 @@ import { UsersRepository } from '../users/repositories/users.repository';
       },
       inject: [ConfigService],
     },
-    UsersRepository,
   ],
   exports: [FcmService],
 })

--- a/src/modules/fcm/interfaces/fcm.interface.ts
+++ b/src/modules/fcm/interfaces/fcm.interface.ts
@@ -24,6 +24,7 @@ export namespace IFcmNotification {
   }
 
   export interface ICreate<T extends NotificationType> extends IBase {
+    notificationType: T;
     data: NotificationDataMap[T];
   }
 }

--- a/src/modules/notifications/services/notification-trigger.service.ts
+++ b/src/modules/notifications/services/notification-trigger.service.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { NotificationRepository } from '../notification.repository';
 import { NotificationHistoryRepository } from '../../notification-histories/repositories/notification-history.repository';
 import { FcmService } from '../../fcm/fcm.service';
-import { NotificationDataMap } from '../types/notification.type';
-import { UpdateRateEvent } from '../../../infrastructure/events/exchange-rate/update-rate.event';
 import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
@@ -59,6 +57,7 @@ export class NotificationTriggerService {
             await this.fcmService.sendNotificationToDevice<'TARGET_PRICE'>(
               userIdx,
               {
+                notificationType: 'TARGET_PRICE',
                 notification: {
                   title: '환율 알림',
                   body: `${currencyCode}가 목표가[${latestRate}]에 도달했습니다`,

--- a/src/modules/users/repositories/users-device.repository.ts
+++ b/src/modules/users/repositories/users-device.repository.ts
@@ -10,6 +10,19 @@ export class UsersDeviceRepository {
     private readonly txHost: TransactionHost<TransactionalAdapterPrisma>,
   ) {}
 
+  async findTokensByUser(userIdx: number): Promise<UserDeviceEntity[]> {
+    return await this.txHost.tx.userDevices
+      .findMany({
+        where: {
+          userIdx,
+          Users: {
+            deletedAt: null,
+          },
+        },
+      })
+      .then((result) => result.map(UserDeviceEntity.from));
+  }
+
   async findTokenByUser(
     userIdx: number,
     deviceToken: string,

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -5,9 +5,8 @@ import { UsersRepository } from './repositories/users.repository';
 import { UsersDeviceRepository } from './repositories/users-device.repository';
 
 @Module({
-  exports: [UsersService],
-  imports: [],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository, UsersDeviceRepository],
+  exports: [UsersService, UsersRepository, UsersDeviceRepository],
 })
 export class UsersModule {}


### PR DESCRIPTION
1. FCM 푸시 알림 메서드 생성
- firebase-admin SDK 연동 및 FcmService 구성
- 알림 유형에 따른 payload 변환 및 발송 로직 구현
- 디바이스 토큰이 없는 경우 로깅 처리 추가 (todo)
- 테스트 커버리지를 위한 mock 기반 단위 테스트 작성

2. 디바이스 토큰 관리 기능 강화
- findTokensByUser, findTokenByUser 메서드 추가
- 중복된 디바이스 토큰 등록 시 upsert 처리
- 관련 통합 테스트 작성 및 afterEach 정리

3. 알림 발송 연동
- 알림 트리거 발생 시 FCM 전송 호출 연동
- NotificationType, notificationType 필드 구조 통합

TODO: 실패 토큰 처리 및 에러 로깅은 로깅 전략 구축 이후 처리 예정