### PR TITLE
@feature/log-strategies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "install": "^0.13.0",
         "ioredis": "^5.4.1",
         "joi": "^17.13.3",
+        "nest-winston": "^1.10.2",
         "nestjs-cls": "^5.0.1",
         "npm": "^10.8.1",
         "passport": "^0.7.0",
@@ -49,7 +50,8 @@
         "socket.io": "^4.8.1",
         "superagent": "^10.1.1",
         "typia": "^7.6.4",
-        "uuid": "^11.0.3"
+        "uuid": "^11.0.3",
+        "winston": "^3.17.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.2",
@@ -769,6 +771,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4027,6 +4040,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/validator": {
       "version": "13.12.2",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
@@ -4832,7 +4851,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-retry": {
@@ -5746,6 +5764,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5763,6 +5791,41 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6523,6 +6586,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -7361,6 +7430,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7667,6 +7742,12 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -10177,6 +10258,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -10380,6 +10467,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/long": {
@@ -10772,6 +10885,19 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nest-winston": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/nest-winston/-/nest-winston-1.10.2.tgz",
+      "integrity": "sha512-Z9IzL/nekBOF/TEwBHUJDiDPMaXUcFquUQOFavIRet6xF0EbuWnOzslyN/ksgzG+fITNgXhMdrL/POp9SdaFxA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-safe-stringify": "^2.1.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "winston": "^3.0.0"
+      }
     },
     "node_modules/nestjs-cls": {
       "version": "5.0.1",
@@ -13602,6 +13728,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -14958,6 +15093,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -15230,6 +15374,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -15481,6 +15640,15 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -16282,6 +16450,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16350,6 +16524,15 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -17077,6 +17260,79 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "install": "^0.13.0",
     "ioredis": "^5.4.1",
     "joi": "^17.13.3",
+    "nest-winston": "^1.10.2",
     "nestjs-cls": "^5.0.1",
     "npm": "^10.8.1",
     "passport": "^0.7.0",
@@ -71,7 +72,8 @@
     "socket.io": "^4.8.1",
     "superagent": "^10.1.1",
     "typia": "^7.6.4",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.2",

--- a/prisma/migrations/20250507133246_add_system_logs/migration.sql
+++ b/prisma/migrations/20250507133246_add_system_logs/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "system_logs" (
+    "id" SERIAL NOT NULL,
+    "level" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "context" TEXT,
+    "trace" TEXT,
+    "timestamp" TIMESTAMPTZ(6) DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "system_logs_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,3 +139,15 @@ model ExchangeRatesRaw {
   @@index([currencyCode, baseCurrency, createdAt(sort: Desc)], map: "idx_exchange_rates_latest")
   @@map("exchange_rates_raw")
 }
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+model SystemLogs {
+  id        Int       @id @default(autoincrement())
+  level     String
+  message   String
+  context   String?
+  trace     String?
+  timestamp DateTime? @default(now()) @db.Timestamptz(6)
+
+  @@map("system_logs")
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { UnhandledExceptionFilter } from './common/filter/unhandled-exception.fi
 import { HttpExceptionFilter } from './common/filter/http-exception.filter';
 import { SuccessResponseInterceptor } from './common/interceptor/response.interceptor';
 import { FcmModule } from './modules/fcm/fcm.module';
+import { CustomLoggerModule } from './common/logger/logger.module';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { FcmModule } from './modules/fcm/fcm.module';
         }),
       ],
     }),
+    CustomLoggerModule,
     UsersModule,
     AuthModule,
     PrismaModule,
@@ -68,7 +70,6 @@ import { FcmModule } from './modules/fcm/fcm.module';
   ],
   providers: [
     LoggerMiddleware,
-    Logger,
     {
       provide: APP_FILTER,
       useClass: UnhandledExceptionFilter,

--- a/src/common/filter/http-exception.filter.ts
+++ b/src/common/filter/http-exception.filter.ts
@@ -4,19 +4,16 @@ import {
   ExceptionFilter,
   HttpException,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
 import { IExceptionResponse } from 'src/common/dto/interfaces/response.interface';
-import { AppConfig } from '../../infrastructure/config/config.type';
+import { CustomLoggerService } from '../logger/custom-logger.service';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
-  constructor(
-    private readonly logger: Logger,
-    private readonly configService: ConfigService<AppConfig, true>,
-  ) {}
+  constructor(private readonly logger: CustomLoggerService) {
+    this.logger.context = HttpExceptionFilter.name;
+  }
 
   private convertErrorMessage(errors: string[]): string {
     return errors.map((err) => `Validation Error: ${err}`).join(', ');
@@ -42,10 +39,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date(),
     };
-
-    if (this.configService.get('nodeEnv') === 'development') {
-      this.logger.debug(exception.stack);
-    }
 
     return res.status(status).json(response);
   }

--- a/src/common/filter/unhandled-exception.filter.ts
+++ b/src/common/filter/unhandled-exception.filter.ts
@@ -3,13 +3,16 @@ import {
   Catch,
   ExceptionFilter,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
 import { IExceptionResponse } from 'src/common/dto/interfaces/response.interface';
+import { CustomLoggerService } from '../logger/custom-logger.service';
 
 @Catch(Error)
 export class UnhandledExceptionFilter implements ExceptionFilter {
-  constructor(private readonly logger: Logger) {}
+  constructor(private readonly logger: CustomLoggerService) {
+    this.logger.context = UnhandledExceptionFilter.name;
+  }
+
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const req = ctx.getRequest();
@@ -23,11 +26,7 @@ export class UnhandledExceptionFilter implements ExceptionFilter {
       timestamp: new Date(),
     };
 
-    this.logger.error(
-      exception.message,
-      exception.stack,
-      UnhandledExceptionFilter.name,
-    );
+    this.logger.error(exception.message, exception.stack);
 
     return res.status(statusCode).send(response);
   }

--- a/src/common/logger/config/wiston-logger.config.ts
+++ b/src/common/logger/config/wiston-logger.config.ts
@@ -1,0 +1,54 @@
+import * as winston from 'winston';
+import { utilities as nestWinstonModuleUtilities } from 'nest-winston';
+
+export const winstonConfig: winston.LoggerOptions = {
+  level: 'debug',
+  transports: [
+    new winston.transports.Console({
+      level: 'debug',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        nestWinstonModuleUtilities.format.nestLike('ExchangeWatch', {
+          colors: true,
+          prettyPrint: true,
+        }),
+      ),
+    }),
+
+    new winston.transports.File({
+      filename: 'logs/debug.log',
+      level: 'debug',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json(),
+      ),
+    }),
+
+    new winston.transports.File({
+      filename: 'logs/warn.log',
+      level: 'warn',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json(),
+      ),
+    }),
+
+    new winston.transports.File({
+      filename: 'logs/error.log',
+      level: 'error',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json(),
+      ),
+    }),
+
+    new winston.transports.File({
+      filename: 'logs/combined.log',
+      level: 'info',
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.json(),
+      ),
+    }),
+  ],
+};

--- a/src/common/logger/custom-logger.service.ts
+++ b/src/common/logger/custom-logger.service.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable, LoggerService, Scope } from '@nestjs/common';
+import { Logger } from 'winston';
+import { LoggerRepository } from './logger.repository';
+
+@Injectable({
+  scope: Scope.TRANSIENT,
+})
+export class CustomLoggerService implements LoggerService {
+  context: string = 'LoggerService';
+
+  constructor(
+    @Inject('winston') private readonly logger: Logger,
+    private readonly loggerRepository: LoggerRepository,
+  ) {}
+
+  async log(message: string) {
+    this.logger.log(message, { context: this.context });
+
+    await this.loggerRepository.saveLog({
+      level: 'LOG',
+      message: message,
+      context: this.context,
+    });
+  }
+
+  async info(message: string) {
+    this.logger.info(message, { context: this.context });
+
+    await this.loggerRepository.saveLog({
+      level: 'INFO',
+      message: message,
+      context: this.context,
+    });
+  }
+
+  async error(message: string, trace?: string) {
+    this.logger.error(message, { trace, context: this.context });
+
+    await this.loggerRepository.saveLog({
+      level: 'ERROR',
+      message: message,
+      context: this.context,
+      trace: trace,
+    });
+  }
+
+  async warn(message: string, trace?: string) {
+    this.logger.warn(message, { context: this.context });
+
+    await this.loggerRepository.saveLog({
+      level: 'WARN',
+      message: message,
+      context: this.context,
+      trace: trace,
+    });
+  }
+
+  debug(message: string) {
+    this.logger.debug(message, { context: this.context });
+  }
+
+  async verbose(message: string) {
+    this.logger.verbose?.(message, { context: this.context });
+  }
+}

--- a/src/common/logger/interfaces/logger.interface.ts
+++ b/src/common/logger/interfaces/logger.interface.ts
@@ -1,0 +1,8 @@
+export namespace ILogger {
+  export interface ICreateLog {
+    level: 'INFO' | 'ERROR' | 'WARN' | 'LOG';
+    message: string;
+    context?: string;
+    trace?: string;
+  }
+}

--- a/src/common/logger/logger.module.ts
+++ b/src/common/logger/logger.module.ts
@@ -1,0 +1,19 @@
+import { Global, Module } from '@nestjs/common';
+import { createLogger } from 'winston';
+import { CustomLoggerService } from './custom-logger.service';
+import { winstonConfig } from './config/wiston-logger.config';
+import { LoggerRepository } from './logger.repository';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: 'winston',
+      useFactory: () => createLogger(winstonConfig),
+    },
+    CustomLoggerService,
+    LoggerRepository,
+  ],
+  exports: [CustomLoggerService],
+})
+export class CustomLoggerModule {}

--- a/src/common/logger/logger.repository.ts
+++ b/src/common/logger/logger.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../infrastructure/database/prisma/prisma.service';
+import { ILogger } from './interfaces/logger.interface';
+
+@Injectable()
+export class LoggerRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async saveLog(input: ILogger.ICreateLog) {
+    await this.prisma.systemLogs.create({
+      data: {
+        level: input.level,
+        message: input.message,
+        context: input.context,
+        trace: input.trace,
+      },
+    });
+
+    return;
+  }
+}

--- a/src/infrastructure/externals/exchange-rates/market-status-scheduler.ts
+++ b/src/infrastructure/externals/exchange-rates/market-status-scheduler.ts
@@ -1,27 +1,29 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { IExchangeRateWebSocketService } from './interfaces/exchange-rate-websocket.interface';
+import { CustomLoggerService } from '../../../common/logger/custom-logger.service';
 
 @Injectable()
 export class MarketStatusScheduler {
-  private readonly logger = new Logger(MarketStatusScheduler.name);
   constructor(
     @Inject('WEBSOCKET_IMPL')
     private readonly collectLatestRateSocket: IExchangeRateWebSocketService,
-  ) {}
+    private readonly logger: CustomLoggerService,
+  ) {
+    this.logger.context = MarketStatusScheduler.name;
+  }
 
   // 매주 일요일 21시 정각 (UTC)
   @Cron('0 21 * * 0')
   handleMarketOpen() {
-    // this.externalWebsocketGateWay.testConnectLatestRateSocketㅇ();
     this.collectLatestRateSocket.connect();
-    this.logger.debug('시장 개장시간이라 latestRate 소켓연결을 시작합니다.');
+    this.logger.info('시장 개장시간이라 latestRate 소켓연결을 시작합니다.');
   }
 
   //   매주 금요일 21시 정각
   @Cron('0 21 * * 5')
   handleMarketClose() {
     this.collectLatestRateSocket.disconnect();
-    this.logger.debug('시장 마감시간이라 latestRate 소켓연결을 해제합니다.');
+    this.logger.info('시장 마감시간이라 latestRate 소켓연결을 해제합니다.');
   }
 }

--- a/src/infrastructure/externals/external-websocket.gateway.ts
+++ b/src/infrastructure/externals/external-websocket.gateway.ts
@@ -1,23 +1,25 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { IExchangeRateWebSocketService } from './exchange-rates/interfaces/exchange-rate-websocket.interface';
 import { DateUtilService } from '../../common/utils/date-util/date-util.service';
+import { CustomLoggerService } from '../../common/logger/custom-logger.service';
 
 @Injectable()
 export class ExternalWebSocketGateWay implements OnModuleInit {
-  private readonly logger: Logger = new Logger(ExternalWebSocketGateWay.name);
-
   constructor(
     @Inject('WEBSOCKET_IMPL')
     private readonly collectLatestRateSocket: IExchangeRateWebSocketService,
     private readonly dateUtilService: DateUtilService,
-  ) {}
+    private readonly logger: CustomLoggerService,
+  ) {
+    this.logger.context = ExternalWebSocketGateWay.name;
+  }
 
   onModuleInit() {
     if (this.dateUtilService.isMarketOpen()) {
-      this.logger.verbose('[개장]: 실시간 환율정보 수집');
+      this.logger.debug('[개장]: 실시간 환율정보 수집');
       this.collectLatestRateSocket.connect();
     } else {
-      this.logger.verbose('[휴장]: 실시간 환율정보 수집 연결하지 않음');
+      this.logger.debug('[휴장]: 실시간 환율정보 수집 연결하지 않음');
     }
   }
 }

--- a/src/infrastructure/redis/subscribers/rate-update.subscriber.ts
+++ b/src/infrastructure/redis/subscribers/rate-update.subscriber.ts
@@ -1,21 +1,16 @@
-import {
-  Injectable,
-  Logger,
-  OnModuleDestroy,
-  OnModuleInit,
-} from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { IRedisSubscriber } from '../interfaces/redis-subsciber.interface';
 import Redis from 'ioredis';
 import { RedisService } from '../redis.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { IRedisSchema } from '../interfaces/redis-schema.interface';
 import { UpdateRateEvent } from '../../events/exchange-rate/update-rate.event';
+import { CustomLoggerService } from '../../../common/logger/custom-logger.service';
 
 @Injectable()
 export class RateUpdateSubscriber
   implements IRedisSubscriber, OnModuleInit, OnModuleDestroy
 {
-  private readonly logger = new Logger(RateUpdateSubscriber.name);
   private readonly subscriber: Redis;
   private readonly rateUpdateChannelPattern = 'rate-update:*';
   private isSubscribed = false;
@@ -23,7 +18,9 @@ export class RateUpdateSubscriber
   constructor(
     private readonly redisService: RedisService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly logger: CustomLoggerService,
   ) {
+    this.logger.context = RateUpdateSubscriber.name;
     this.subscriber = this.redisService.duplicate;
   }
 
@@ -44,7 +41,7 @@ export class RateUpdateSubscriber
 
       this.subscriber.on('pmessage', this.handleMessage.bind(this));
 
-      this.logger.debug(`Subscribed '${this.rateUpdateChannelPattern}'`);
+      this.logger.info(`Subscribed '${this.rateUpdateChannelPattern}'`);
     } catch (error) {
       this.logger.error(`Failed subscribed: ${error.message}`, error.stack);
       throw error;

--- a/src/modules/exchange-rate/listeners/latest-rate.listener.ts
+++ b/src/modules/exchange-rate/listeners/latest-rate.listener.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ExchangeRateService } from '../services/exchange-rate.service';
 import { LatestRateEvent } from '../../../infrastructure/events/exchange-rate/latest-rate.event';
@@ -6,8 +6,6 @@ import { ExchangeRateRedisService } from '../services/exchange-rate-redis.servic
 
 @Injectable()
 export class LatestRateListener {
-  private readonly logger: Logger = new Logger(LatestRateListener.name);
-
   constructor(
     private readonly exchangeRateRedisService: ExchangeRateRedisService,
     private readonly exchangeRateService: ExchangeRateService,
@@ -31,10 +29,6 @@ export class LatestRateListener {
       event.currencyCode,
       event.rate,
       event.timestamp,
-    );
-
-    this.logger.debug(
-      `update latest-rate healthcheck!!: ${event.baseCurrency}/${event.currencyCode}`,
     );
   }
 }

--- a/src/modules/exchange-rate/listeners/update-rate.listener.ts
+++ b/src/modules/exchange-rate/listeners/update-rate.listener.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { LatestRateSseService } from '../../sse/services/latest-rate-sse.service';
 import { UpdateRateEvent } from '../../../infrastructure/events/exchange-rate/update-rate.event';
@@ -6,7 +6,6 @@ import { NotificationTriggerService } from '../../notifications/services/notific
 
 @Injectable()
 export class UpdateRateListener {
-  private readonly logger = new Logger(UpdateRateListener.name);
   constructor(
     private readonly exchangeRateSseService: LatestRateSseService,
     private readonly notificationTriggerService: NotificationTriggerService,

--- a/src/modules/fcm/__test__/unit/fcm.service.spec.ts
+++ b/src/modules/fcm/__test__/unit/fcm.service.spec.ts
@@ -1,36 +1,54 @@
 import { Test } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
-import { app, messaging } from 'firebase-admin';
+import { app, FirebaseError } from 'firebase-admin';
 import { FcmService } from '../../fcm.service';
 import { UsersDeviceRepository } from '../../../users/repositories/users-device.repository';
 import { UserDeviceEntity } from '../../../users/entities/user-device.entity';
-import typia from 'typia';
-import { MulticastMessage } from 'firebase-admin/lib/messaging/messaging-api';
-import {
-  NOTIFICATION_TYPES,
-  NotificationDataMap,
-  NotificationType,
-} from '../../../notifications/types/notification.type';
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { IFcmNotification } from '../../interfaces/fcm.interface';
+
+const createMockFirebaseError = (
+  message: string,
+  code: string,
+  stack?: string,
+): FirebaseError => {
+  const error = new Error(message) as unknown as FirebaseError;
+  error.code = code;
+  error.stack = stack || new Error(message).stack;
+  return error;
+};
 
 describe('FcmService [unit]', () => {
   let fcmService: FcmService;
-  let firebaseMock: MockProxy<app.App>;
-  let usersDeviceRepository: MockProxy<UsersDeviceRepository>;
+  let firebaseAppMock: MockProxy<app.App>;
+  let usersDeviceRepositoryMock: MockProxy<UsersDeviceRepository>;
+  let loggerServiceMock: MockProxy<CustomLoggerService>;
+  let sendEachForMulticastMock: jest.Mock;
 
   beforeEach(async () => {
-    firebaseMock = mock<app.App>();
-    usersDeviceRepository = mock<UsersDeviceRepository>();
+    firebaseAppMock = mock<app.App>();
+    usersDeviceRepositoryMock = mock<UsersDeviceRepository>();
+    loggerServiceMock = mock<CustomLoggerService>();
+
+    sendEachForMulticastMock = jest.fn();
+    (firebaseAppMock.messaging as jest.Mock).mockImplementation(() => ({
+      sendEachForMulticast: sendEachForMulticastMock,
+    }));
 
     const module = await Test.createTestingModule({
       providers: [
         FcmService,
         {
+          provide: CustomLoggerService,
+          useValue: loggerServiceMock,
+        },
+        {
           provide: 'FCM_ADMIN',
-          useValue: firebaseMock,
+          useValue: firebaseAppMock,
         },
         {
           provide: UsersDeviceRepository,
-          useValue: usersDeviceRepository,
+          useValue: usersDeviceRepositoryMock,
         },
       ],
     }).compile();
@@ -38,20 +56,14 @@ describe('FcmService [unit]', () => {
     fcmService = module.get(FcmService);
   });
 
-  it('should be definded', () => {
+  it('should be defined', () => {
     expect(fcmService).toBeDefined();
   });
 
-  describe('sendNotificationToDevice', () => {
-    it('should send FCM with correct targetPrice payload', async () => {
-      // Arrange
-      const userIdx = 1;
-      const mockTokens = ['token_1', 'token_2'];
-      usersDeviceRepository.findTokensByUser.mockResolvedValue(
-        mockTokens.map((e) => ({ deviceToken: e })) as UserDeviceEntity[],
-      );
-      const notificationPayload = {
-        notificationType: NOTIFICATION_TYPES.TARGET_PRICE,
+  describe('sendNotificationToDevice [TARGET_PRICE]', () => {
+    const defaultNotificationPayload: IFcmNotification.ICreate<'TARGET_PRICE'> =
+      {
+        notificationType: 'TARGET_PRICE',
         notification: {
           title: 'targetPrice notification title',
           body: 'targetPrice notification body',
@@ -63,37 +75,126 @@ describe('FcmService [unit]', () => {
         },
       };
 
-      // Act
-      const sendEachMock = jest.fn().mockResolvedValue({
+    it('정상적인 페이로드로 FCM 메시지를 전송해야 한다', async () => {
+      // Arrange
+      const userIdx = 1;
+      const mockTokens = ['token_1', 'token_2'];
+      usersDeviceRepositoryMock.findTokensByUser.mockResolvedValue(
+        mockTokens.map((e) => ({ deviceToken: e }) as UserDeviceEntity),
+      );
+      sendEachForMulticastMock.mockResolvedValue({
         successCount: 2,
         failureCount: 0,
-        responses: [],
+        responses: [
+          { success: true, messageId: 'idx1' },
+          { success: true, messageId: 'idx2' },
+        ],
       });
 
-      (firebaseMock.messaging as () => messaging.Messaging) = () =>
-        ({ sendEachForMulticast: sendEachMock }) as any;
+      // Act
+      await fcmService.sendNotificationToDevice(
+        userIdx,
+        defaultNotificationPayload,
+      );
 
       // Assert
-      await fcmService.sendNotificationToDevice<'TARGET_PRICE'>(userIdx, {
-        data: notificationPayload.data,
-        notification: notificationPayload.notification,
-        notificationType: notificationPayload.notificationType,
-      });
-
-      expect(sendEachMock).toHaveBeenCalledWith({
+      expect(sendEachForMulticastMock).toHaveBeenCalledWith({
         data: {
-          type: notificationPayload.notificationType,
-          payload: JSON.stringify(notificationPayload.data),
+          type: defaultNotificationPayload.notificationType,
+          payload: JSON.stringify(defaultNotificationPayload.data),
         },
         notification: {
-          ...notificationPayload.notification,
+          ...defaultNotificationPayload.notification,
         },
         tokens: mockTokens,
       });
+
+      expect(loggerServiceMock.verbose).toHaveBeenCalledWith(
+        `메시지 발송 성공. userIdx: ${userIdx}, type: TARGET_PRICE`,
+      );
     });
 
-    it.todo('should log if tokens are not exist');
-    it.todo('should log warnings for failed tokens');
-    it.todo('should throw error if firebase throws');
+    it('만약 디바이스 토큰이 없을 경우 경고 로그를 남겨야 한다', async () => {
+      // Arrange
+      const userIdx = 1;
+      usersDeviceRepositoryMock.findTokensByUser.mockResolvedValue([]);
+
+      // Act
+      await fcmService.sendNotificationToDevice(
+        userIdx,
+        defaultNotificationPayload,
+      );
+
+      // Assert
+      expect(sendEachForMulticastMock).not.toHaveBeenCalled();
+      expect(loggerServiceMock.log).toHaveBeenCalledWith(
+        `해당하는 사용자의 디바이스 토큰이 존재하지 않습니다: user: ${userIdx}`,
+      );
+    });
+
+    it('일부 토큰 발송 실패 시, 실패 건에 대해 에러 로그를 남긴다.', async () => {
+      // Arrange
+      const userIdx = 1;
+      const mockTokens = ['token_1'];
+      usersDeviceRepositoryMock.findTokensByUser.mockResolvedValue(
+        mockTokens.map((e) => ({ deviceToken: e }) as UserDeviceEntity),
+      );
+      sendEachForMulticastMock.mockResolvedValue({
+        successCount: 1,
+        failureCount: 1,
+        responses: [
+          {
+            success: false,
+            messageId: 'idx1',
+            error: {
+              code: 'firebaseErrorCode',
+              message: 'firebaseErrorMessage',
+              stack: 'firebaseErrorStack',
+            },
+          },
+          { success: true, messageId: 'idx2' },
+        ],
+      });
+
+      // Act
+      await fcmService.sendNotificationToDevice(
+        userIdx,
+        defaultNotificationPayload,
+      );
+
+      // Assert
+      expect(loggerServiceMock.error).toHaveBeenCalledWith(
+        `발송 실패. userIdx: ${userIdx}, type: TARGET_PRICE, [firebaseErrorCode]: firebaseErrorMessage`,
+        'firebaseErrorStack',
+      );
+    });
+
+    it('sendEachForMulticast API 호출 자체가 실패할 경우 에러 로그를 남겨야 한다', async () => {
+      // Arrange
+      const userIdx = 1;
+      const mockTokens = ['token_1'];
+      usersDeviceRepositoryMock.findTokensByUser.mockResolvedValue(
+        mockTokens.map((e) => ({ deviceToken: e }) as UserDeviceEntity),
+      );
+
+      const globalError = createMockFirebaseError(
+        'Global Firebase API error',
+        'UNAVAILABLE',
+        'globalStackTrace',
+      );
+      sendEachForMulticastMock.mockRejectedValue(globalError); // 여기도 변경
+
+      // Act
+      await fcmService.sendNotificationToDevice(
+        userIdx,
+        defaultNotificationPayload,
+      );
+
+      // Assert
+      expect(loggerServiceMock.error).toHaveBeenCalledWith(
+        `메시지 전체 발송 실패, userIdx: 1, Error: ${globalError.message}, code: ${globalError.code}`,
+        globalError.stack,
+      );
+    });
   });
 });

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { IUser } from './interfaces/user.interface';
 import { UserEntity } from './entities/user.entity';
 import { UserNotFoundException } from './exceptions/user-not-found.exception';
@@ -6,14 +6,17 @@ import { UsersRepository } from './repositories/users.repository';
 import { UsersDeviceRepository } from './repositories/users-device.repository';
 import { IUserDevice } from './interfaces/user-device.interface';
 import { Transactional } from '@nestjs-cls/transactional';
+import { CustomLoggerService } from '../../common/logger/custom-logger.service';
 
 @Injectable()
 export class UsersService {
-  private readonly logger: Logger = new Logger(UsersService.name);
   constructor(
     private readonly usersRepository: UsersRepository,
     private readonly usersDeviceRepository: UsersDeviceRepository,
-  ) {}
+    private readonly logger: CustomLoggerService,
+  ) {
+    this.logger.context = UsersService.name;
+  }
 
   async findUserByIdx(userIdx: number): Promise<UserEntity> {
     const existUser = await this.usersRepository.findUserByIdx(userIdx);
@@ -76,7 +79,7 @@ export class UsersService {
       deviceToken,
     );
     if (!checkHasToken) {
-      this.logger.log(
+      this.logger.verbose(
         `No device token found for user ${userIdx} and token ${deviceToken}`,
       );
       return;


### PR DESCRIPTION
## 개요
- 기본 nestjs LoggerService를  winston-nestjs라이브러리를 이용해서 대체.

## 주요 변경사항
- CustomLoggerModule (global module) 및 CustomLoggerService 생성
- system_log테이블 생성 및 prisma sceham migration 생성
- 따로 기록이 필요한 로그일 경우 CustomLoggerService를 생성자주입받아서 로깅

- 로그 레벨별로 나눠서 각각의 transport를 지정. 모든 레벨은 `node_enviroment === development`일때만 콘솔에 출력.
  - debug: 서버 디스크에 debug.log에 저장. (단순 개발 시 컨텍스트 확인용도)
  - info: 서버 디스크에 info.log에 저장 및 데이터베이스 테이블에 저장
    - (정상적인 흐름을 설명할 때. 사용자 행위, 시스템 이벤트 요약 등, 추후 사용자 분석에 용이하게)
    - verbose: 서버 디스크에 verbose.log에 저장 (디버깅 또는 자세한 내부 흐름 추적용. info보다 더 세세한 정보)
  - warn: 서버 디스크에 warn.log에 저장 및 데이터베이스 테이블에 저장 (문제 가능성이 있는 상태 또는 의도한 에러일 경우. )
  - error: 서버 디스크에 error.log에 저장 및 데이터베이스 테이블에 저장 (외부 api 장애 혹은 개발자 실수로 인한 500에러 혹은 예기치 못한 에러)
- debug레벨을 제외한 상위 로그 레벨은 전부 단위 테스트 대상. (의도한 레벨의 로그로 호출됐는지. 포맷 형식 등)

## 기타

