### PR TITLE
Add `leader-election`strategy for server clustered enviroment

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -8,13 +8,13 @@ RUN apk add --no-cache openssl
 
 WORKDIR /usr/src/app
 
+# Copy package & prisma files
 COPY package*.json ./
+COPY prisma ./prisma/
 
+# Install dependencies
 RUN npm install
 
-# Setting Prisma client
-COPY prisma ./prisma/
-RUN npx prisma generate
 # Copy source codes
 COPY . .
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -31,6 +31,7 @@ import { SuccessResponseInterceptor } from './common/interceptor/response.interc
 import { FcmModule } from './modules/fcm/fcm.module';
 import { CustomLoggerModule } from './common/logger/logger.module';
 import { AgentModule } from './common/agents/agents.module';
+import { ClusterModule } from './infrastructure/cluster/cluster.module';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { AgentModule } from './common/agents/agents.module';
         }),
       ],
     }),
+    ClusterModule,
     AgentModule,
     CustomLoggerModule,
     UsersModule,

--- a/src/infrastructure/cluster/cluster.module.ts
+++ b/src/infrastructure/cluster/cluster.module.ts
@@ -1,0 +1,36 @@
+import { Module, OnApplicationBootstrap } from '@nestjs/common';
+import { RedisModule } from '../redis/redis.module';
+import { RoleModule } from './role/role.module';
+import { LeaderElectionService } from './leader-election.service';
+import { RoleService } from './role/role.service';
+import { ExchangeRateModule } from '../../modules/exchange-rate/exchange-rate.module';
+import { ExternalAPIModule } from '../externals/external.module';
+import { ExchangeRateService } from '../../modules/exchange-rate/services/exchange-rate.service';
+import { ExternalWebSocketGateWay } from '../externals/external-websocket.gateway';
+
+@Module({
+  imports: [RedisModule, RoleModule, ExchangeRateModule, ExternalAPIModule],
+  providers: [LeaderElectionService],
+})
+export class ClusterModule implements OnApplicationBootstrap {
+  constructor(
+    private readonly electionService: LeaderElectionService,
+    private readonly roleService: RoleService,
+    private readonly exchangeRateService: ExchangeRateService,
+    private readonly websocketGateway: ExternalWebSocketGateWay,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    // 리더가 선출될때까지 대기
+    await this.electionService.elect();
+
+    // 리더가 선출되면 작업 시작.
+    if (this.roleService.isLeader) {
+      // 외부 API로부터 캐시 웜업
+      await this.exchangeRateService.initializeAllCurrencyData();
+
+      // 소켓 커넥션 시작
+      this.websocketGateway.startConnection();
+    }
+  }
+}

--- a/src/infrastructure/cluster/leader-election.service.ts
+++ b/src/infrastructure/cluster/leader-election.service.ts
@@ -1,0 +1,107 @@
+import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
+import { RedisService } from '../../infrastructure/redis/redis.service';
+import { RoleService } from './role/role.service';
+import { CustomLoggerService } from '../../common/logger/custom-logger.service';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class LeaderElectionService implements OnApplicationShutdown {
+  private readonly instanceId = uuidv4();
+  private readonly lockKey = 'leader-lock:collector';
+  private readonly lockTtl = 60; // 락 유효시간: 60초
+
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+  private watcherInterval: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly roleService: RoleService,
+    private readonly loggerService: CustomLoggerService,
+  ) {
+    this.loggerService.context = `LeaderElection:${this.instanceId.slice(0, 8)}`;
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    this.clearAllTimers();
+    if (this.roleService.isLeader) {
+      await this.redisService.releaseLock(this.lockKey);
+      this.loggerService.debug('Released leader lock on shutdown.');
+    }
+  }
+
+  /**
+   * 리더 선출
+   */
+  async elect(): Promise<void> {
+    this.loggerService.verbose('Attempting to acquire leader lock...');
+    const isLockAcquired = await this.redisService.setLock(
+      this.lockKey,
+      this.instanceId,
+      this.lockTtl,
+    );
+
+    if (isLockAcquired) {
+      this.roleService.setAsLeader();
+      this.clearWatcher();
+      this.startHeartbeat();
+      this.loggerService.verbose(
+        '>>> Lock acquired. This instance is now the LEADER',
+      );
+    } else {
+      this.roleService.setAsWorker();
+      this.clearHeartbeat();
+      this.startWatching();
+      this.loggerService.verbose(
+        '>>> Failed to acquire lock. This instance is a WORKER',
+      );
+    }
+  }
+
+  /**
+   * 리더가 살아있다면, lock을 임계시간마다 리뉴얼
+   */
+  private startHeartbeat(): void {
+    const renewalInterval = this.lockTtl * 1000 * 0.75; // 45초마다
+    this.heartbeatInterval = setInterval(async () => {
+      this.loggerService.debug('Renewing leader lock...');
+      const renewed = await this.redisService.renewLock(
+        this.lockKey,
+        this.lockTtl,
+      );
+      if (!renewed) {
+        this.loggerService.warn(
+          'Failed to renew lock. Stepping down as leader.',
+        );
+        await this.elect();
+      }
+    }, renewalInterval);
+  }
+
+  /**
+   * 리더가 살아있는지 주기적으로 확인
+   */
+  private startWatching(): void {
+    const watcherInterval = 15 * 1000; // 15초마다
+    this.watcherInterval = setInterval(async () => {
+      const leaderId = await this.redisService.getRaw(this.lockKey);
+      if (!leaderId) {
+        this.loggerService.warn(
+          'Leader lock not found. Attempting to become new leader...',
+        );
+        await this.elect();
+      }
+    }, watcherInterval);
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
+  }
+  private clearWatcher(): void {
+    if (this.watcherInterval) clearInterval(this.watcherInterval);
+  }
+
+  private clearAllTimers(): void {
+    this.clearHeartbeat();
+    this.clearWatcher();
+  }
+}

--- a/src/infrastructure/cluster/role/role.module.ts
+++ b/src/infrastructure/cluster/role/role.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { RoleService } from './role.service';
+
+@Global()
+@Module({
+  providers: [RoleService],
+  exports: [RoleService],
+})
+export class RoleModule {}

--- a/src/infrastructure/cluster/role/role.service.ts
+++ b/src/infrastructure/cluster/role/role.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RoleService {
+  private _isLeader = false;
+
+  /**
+   * Check if the instance is leader
+   */
+  public get isLeader(): boolean {
+    return this._isLeader;
+  }
+
+  /**
+   * Set the current instance role as leader
+   */
+  public setAsLeader(): void {
+    this._isLeader = true;
+  }
+
+  /**
+   * Set the current instance role as worker
+   */
+  public setAsWorker(): void {
+    this._isLeader = false;
+  }
+}

--- a/src/infrastructure/externals/external-websocket.gateway.ts
+++ b/src/infrastructure/externals/external-websocket.gateway.ts
@@ -1,10 +1,10 @@
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { IExchangeRateWebSocketService } from './exchange-rates/interfaces/exchange-rate-websocket.interface';
 import { DateUtilService } from '../../common/utils/date-util/date-util.service';
 import { CustomLoggerService } from '../../common/logger/custom-logger.service';
 
 @Injectable()
-export class ExternalWebSocketGateWay implements OnModuleInit {
+export class ExternalWebSocketGateWay {
   constructor(
     @Inject('WEBSOCKET_IMPL')
     private readonly collectLatestRateSocket: IExchangeRateWebSocketService,
@@ -14,7 +14,7 @@ export class ExternalWebSocketGateWay implements OnModuleInit {
     this.logger.context = ExternalWebSocketGateWay.name;
   }
 
-  onModuleInit() {
+  startConnection() {
     if (this.dateUtilService.isMarketOpen()) {
       this.logger.debug('[개장]: 실시간 환율정보 수집');
       this.collectLatestRateSocket.connect();

--- a/src/infrastructure/externals/external.module.ts
+++ b/src/infrastructure/externals/external.module.ts
@@ -34,6 +34,7 @@ import { FrankFurtherService } from './exchange-rates/frankfurther/frankfurther.
     'FLUCTUATION_RATE_API',
     'TIMESERIES_RATE_API',
     'WEBSOCKET_IMPL',
+    ExternalWebSocketGateWay,
   ],
 })
 export class ExternalAPIModule {}

--- a/src/infrastructure/redis/redis.module.ts
+++ b/src/infrastructure/redis/redis.module.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis';
-import { Logger, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { ConfigService } from '@nestjs/config';
 import { AppConfig } from '../config/config.type';
@@ -19,8 +19,7 @@ import { RateUpdateSubscriber } from './subscribers/rate-update.subscriber';
     },
     RedisService,
     RateUpdateSubscriber,
-    Logger,
   ],
-  exports: ['REDIS_CLIENT'],
+  exports: [RedisService],
 })
 export class RedisModule {}

--- a/src/infrastructure/redis/redis.service.ts
+++ b/src/infrastructure/redis/redis.service.ts
@@ -74,4 +74,33 @@ export class RedisService implements OnModuleDestroy {
   get duplicate(): Redis {
     return this.redisClient.duplicate();
   }
+
+  /**
+   * Setting redis lock
+   * @param key key of lock
+   * @param value value of lock
+   * @param ttl time to live
+   */
+  async setLock(key: string, value: string, ttl: number): Promise<boolean> {
+    const result = await this.redisClient.set(key, value, 'EX', ttl, 'NX');
+    return result === 'OK';
+  }
+
+  /**
+   * Release redis lock
+   * @param key key of lock
+   */
+  async releaseLock(key: string): Promise<void> {
+    await this.redisClient.del(key);
+  }
+
+  /**
+   * Renewal lock TTL
+   * @param key key of lock
+   * @param ttl time to live
+   */
+  async renewLock(key: string, ttl: number): Promise<boolean> {
+    const result = await this.redisClient.expire(key, ttl);
+    return result === 1;
+  }
 }

--- a/src/infrastructure/redis/redis.service.ts
+++ b/src/infrastructure/redis/redis.service.ts
@@ -1,26 +1,41 @@
-import { Injectable, Inject, OnModuleDestroy, Logger } from '@nestjs/common';
+import { Injectable, Inject, OnModuleDestroy } from '@nestjs/common';
 import { Redis } from 'ioredis';
+import { CustomLoggerService } from '../../common/logger/custom-logger.service';
 
 @Injectable()
 export class RedisService implements OnModuleDestroy {
-  protected readonly logger = new Logger(RedisService.name);
   protected subscriber: Redis;
 
-  constructor(@Inject('REDIS_CLIENT') protected readonly redisClient: Redis) {}
+  constructor(
+    @Inject('REDIS_CLIENT') protected readonly redisClient: Redis,
+    private readonly loggerService: CustomLoggerService,
+  ) {
+    this.loggerService.context = RedisService.name;
+  }
 
   onModuleDestroy() {
+    this.loggerService.debug('Redis client destroyed');
     this.redisClient.quit();
   }
 
   /**
-   * Redis default get
+   * Redis default get with serialization
    * @param key
-   * @returns
+   * @returns serialized data or null
    */
   async get<T = string>(key: string): Promise<T | null> {
     const rawData = await this.redisClient.get(key);
 
     return rawData ? (JSON.parse(rawData) as T) : null;
+  }
+
+  /**
+   * Redis default get without serialization
+   * @param key
+   * @returns raw data or null
+   */
+  async getRaw(key: string): Promise<string | null> {
+    return await this.redisClient.get(key);
   }
 
   /**

--- a/src/infrastructure/redis/subscribers/rate-update.subscriber.ts
+++ b/src/infrastructure/redis/subscribers/rate-update.subscriber.ts
@@ -80,7 +80,7 @@ export class RateUpdateSubscriber
       await this.subscriber.punsubscribe(this.rateUpdateChannelPattern);
       this.subscriber.removeAllListeners('pmessage');
       this.isSubscribed = false;
-      this.logger.log(
+      this.logger.info(
         `Release redis subscribe about: ${this.rateUpdateChannelPattern}`,
       );
     } catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ async function bootstrap() {
 
   app.setGlobalPrefix('api');
   app.use(cookieParser());
+  app.enableShutdownHooks();
 
   setSwagger(app);
 

--- a/src/modules/exchange-rate/exchange-rate.module.ts
+++ b/src/modules/exchange-rate/exchange-rate.module.ts
@@ -1,4 +1,4 @@
-import { Module, OnModuleInit } from '@nestjs/common';
+import { Module, OnApplicationBootstrap, OnModuleInit } from '@nestjs/common';
 import { ExchangeRateService } from './services/exchange-rate.service';
 import { ExchangeRateController } from './controllers/exchange-rate.controller';
 import { RedisModule } from '../../infrastructure/redis/redis.module';
@@ -13,9 +13,9 @@ import { IsAfterConstraint } from '../../common/decorators/validations/is-after.
 import { IsBeforeThanConstraint } from '../../common/decorators/validations/is-before-than.validator';
 import { SseModule } from '../sse/sse.module';
 import { ExchangeRateRedisService } from './services/exchange-rate-redis.service';
-import { RedisService } from '../../infrastructure/redis/redis.service';
 import { NotificationModule } from '../notifications/notification.module';
 import { CustomLoggerService } from '../../common/logger/custom-logger.service';
+import { RoleService } from '../../infrastructure/cluster/role/role.service';
 
 @Module({
   imports: [
@@ -27,7 +27,6 @@ import { CustomLoggerService } from '../../common/logger/custom-logger.service';
   ],
   controllers: [ExchangeRateController],
   providers: [
-    RedisService,
     ExchangeRateService,
     ExchangeRateRedisService,
     ExchangeRateScheduler,
@@ -40,25 +39,4 @@ import { CustomLoggerService } from '../../common/logger/custom-logger.service';
   ],
   exports: [ExchangeRateService],
 })
-export class ExchangeRateModule implements OnModuleInit {
-  constructor(
-    private readonly exchangeRateService: ExchangeRateService,
-    private readonly loggerService: CustomLoggerService,
-  ) {
-    this.loggerService.context = ExchangeRateModule.name;
-  }
-
-  async onModuleInit() {
-    try {
-      this.loggerService.debug(
-        'Try to initializing currency rate for cache warm up from external api',
-      );
-      await this.exchangeRateService.initializeAllCurrencyData();
-    } catch (error) {
-      this.loggerService.warn(
-        'failed to init currency data from external api',
-        error,
-      );
-    }
-  }
-}
+export class ExchangeRateModule {}


### PR DESCRIPTION
### 🚀 Summary
- Definded several `single job` for clustered enviroment. and moved `single job` logics to cluster module.
- Defined `leader-election`strategy used by redis `SETNX` (distributed lock) for each single job
---

### 💡 Motivation and Context
I could successfully executed on a single instance, but If run on the clustered enviroments, I faced the several issued.
Firstly, I can define the `single job` that must be execute only once while working on clustered env. 

- `Websocket connection` (for recive real-time exchange-rate from external API)
- `Cache warm up` when started server.
- `Schedulers`
- more..

So, moved exist `singleton jobs` to the `cluster module` and 
At the cluster module, there are a series of steps that go into the leader-election process.

And implement several methods for redis-lock using `SETNX` keyword in `RedisService`

At LeaderElectionService.elect, Each instance acquires a Redis lock to elect a leader instance.

---

### Extra changes
- reordered prisma command in dockerfile before `npm install`
- export `ExternalWebSocketGateway`
- export `RedisService` instead redis-client provider token


### TODO
- Update `scheduler strategy`
---
