### PR TITLE
Refactor: update leader-election strategy

### DIFF
--- a/src/infrastructure/cluster/__test__/integration/leader-election.integration.spec.ts
+++ b/src/infrastructure/cluster/__test__/integration/leader-election.integration.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeaderElectionService } from '../../leader-election.service';
+import { RedisService } from '../../../redis/redis.service';
+import { RoleService } from '../../role/role.service';
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { TestIntegrateModules } from '../../../../../test/integration/utils/integrate-module.util';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { ExternalWebSocketGateWay } from '../../../externals/external-websocket.gateway';
+import { DateUtilService } from '../../../../common/utils/date-util/date-util.service';
+
+describe('LeaderElectionService Integration', () => {
+  let service: LeaderElectionService;
+  let redisService: RedisService;
+  let roleService: RoleService;
+  let loggerService: CustomLoggerService = mock<CustomLoggerService>();
+  let dateUtilService: MockProxy<DateUtilService>;
+  let websocketGateway: MockProxy<ExternalWebSocketGateWay>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [...TestIntegrateModules.create()],
+      providers: [
+        RedisService,
+        LeaderElectionService,
+        RoleService,
+        {
+          provide: DateUtilService,
+          useValue: mock<DateUtilService>(),
+        },
+        {
+          provide: CustomLoggerService,
+          useValue: loggerService,
+        },
+        CustomLoggerService,
+        {
+          provide: ExternalWebSocketGateWay,
+          useValue: mock<ExternalWebSocketGateWay>(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<LeaderElectionService>(LeaderElectionService);
+    redisService = module.get<RedisService>(RedisService);
+    roleService = module.get<RoleService>(RoleService);
+    loggerService =
+      await module.resolve<CustomLoggerService>(CustomLoggerService);
+    dateUtilService = module.get(DateUtilService);
+    websocketGateway = module.get(ExternalWebSocketGateWay);
+  });
+
+  afterEach(async () => {
+    await redisService.del('leader-lock:collector');
+  });
+
+  describe('Blue-Green 배포 시나리오', () => {
+    it('Blue 컨테이너가 Leader이고 Green 컨테이너가 배포될 때', async () => {
+      // Arrange: Blue 컨테이너가 이미 리더 락 보유
+      await redisService.setLock(
+        'leader-lock:collector',
+        'blue-container-id',
+        60,
+      );
+
+      // Act: Green 컨테이너가 리더 선출 시도
+      await service.elect();
+
+      // Assert: Green은 어쩔수없이 Worker가 됨
+      expect(roleService.isLeader).toBe(false);
+    });
+
+    it('Blue 컨테이너 종료 후 재선출 시 Green이 리더 획득하면 바로 소켓연결을 시작한다', async () => {
+      // Arrange: 리더 락이 없는 상태 (blue 종료됨)
+      dateUtilService.isMarketOpen.mockReturnValue(true);
+      await redisService.del('leader-lock:collector');
+
+      // Act: Green이 리더 선출
+      await service.elect();
+
+      // Assert
+      expect(roleService.isLeader).toBe(true);
+      expect(websocketGateway.startConnection).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/infrastructure/cluster/cluster.module.ts
+++ b/src/infrastructure/cluster/cluster.module.ts
@@ -28,9 +28,6 @@ export class ClusterModule implements OnApplicationBootstrap {
     if (this.roleService.isLeader) {
       // 외부 API로부터 캐시 웜업
       await this.exchangeRateService.initializeAllCurrencyData();
-
-      // 소켓 커넥션 시작
-      this.websocketGateway.startConnection();
     }
   }
 }

--- a/src/infrastructure/externals/__test__/unit/external-websocket.gateway.spec.ts
+++ b/src/infrastructure/externals/__test__/unit/external-websocket.gateway.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExternalWebSocketGateWay } from '../../external-websocket.gateway';
+import { IExchangeRateWebSocketService } from '../../exchange-rates/interfaces/exchange-rate-websocket.interface';
+import { DateUtilService } from '../../../../common/utils/date-util/date-util.service';
+import { CustomLoggerService } from '../../../../common/logger/custom-logger.service';
+import { mock, MockProxy } from 'jest-mock-extended';
+
+describe('ExternalWebSocketGateWay', () => {
+  let externalGateway: ExternalWebSocketGateWay;
+  let websocketService: MockProxy<IExchangeRateWebSocketService>;
+  let dateUtilService: MockProxy<DateUtilService>;
+  let customLoggerService: MockProxy<CustomLoggerService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExternalWebSocketGateWay,
+        {
+          provide: 'WEBSOCKET_IMPL',
+          useValue: mock<IExchangeRateWebSocketService>(),
+        },
+        {
+          provide: DateUtilService,
+          useValue: mock<DateUtilService>(),
+        },
+        {
+          provide: CustomLoggerService,
+          useValue: mock<CustomLoggerService>(),
+        },
+      ],
+    }).compile();
+
+    externalGateway = module.get(ExternalWebSocketGateWay);
+    websocketService = module.get('WEBSOCKET_IMPL');
+    dateUtilService = module.get(DateUtilService);
+    customLoggerService = module.get(CustomLoggerService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('startConnection', () => {
+    it('시장 개장 시간에 WebSocket 연결을 시작해야 함', () => {
+      // Arrange: 시장이 열려있음
+      dateUtilService.isMarketOpen.mockReturnValue(true);
+
+      // Act: 연결 시작
+      externalGateway.startConnection();
+
+      // Assert: WebSocket 연결 및 로그 출력
+      expect(dateUtilService.isMarketOpen).toHaveBeenCalledTimes(1);
+      expect(websocketService.connect).toHaveBeenCalledTimes(1);
+      expect(customLoggerService.debug).toHaveBeenCalledWith(
+        '[개장]: 실시간 환율정보 수집',
+      );
+    });
+
+    it('시장 휴장 시간에 WebSocket 연결하지 않아야 함', () => {
+      // Arrange: 시장이 닫혀있음
+      dateUtilService.isMarketOpen.mockReturnValue(false);
+
+      // Act: 연결 시작
+      externalGateway.startConnection();
+
+      // Assert: WebSocket 연결하지 않고 로그만 출력
+      expect(dateUtilService.isMarketOpen).toHaveBeenCalledTimes(1);
+      expect(websocketService.connect).not.toHaveBeenCalled();
+      expect(customLoggerService.debug).toHaveBeenCalledWith(
+        '[휴장]: 실시간 환율정보 수집 연결하지 않음',
+      );
+    });
+  });
+
+  describe('리더 전환 시나리오', () => {
+    it('새로운 리더가 된 후 시장 개장 시간에 WebSocket 연결', () => {
+      // Arrange: 시장이 열려있음
+      dateUtilService.isMarketOpen.mockReturnValue(true);
+
+      // Act: 새 리더가 WebSocket 연결 시작
+      externalGateway.startConnection();
+
+      // Assert: 즉시 WebSocket 연결
+      expect(websocketService.connect).toHaveBeenCalledTimes(1);
+      expect(customLoggerService.debug).toHaveBeenCalledWith(
+        '[개장]: 실시간 환율정보 수집',
+      );
+    });
+
+    it('휴장 시간에 새 리더가 되어도 WebSocket 연결하지 않음', () => {
+      // Arrange: 시장이 닫혀있음
+      dateUtilService.isMarketOpen.mockReturnValue(false);
+
+      // Act: 휴장 시간에 새 리더가 연결 시도
+      externalGateway.startConnection();
+
+      // Assert: WebSocket 연결하지 않음
+      expect(websocketService.connect).not.toHaveBeenCalled();
+      expect(customLoggerService.debug).toHaveBeenCalledWith(
+        '[휴장]: 실시간 환율정보 수집 연결하지 않음',
+      );
+    });
+  });
+});


### PR DESCRIPTION
### 🚀 Summary
- 리더선출 시 행위(전략) 수정
---

### 💡 Motivation and Context
`블루-그린`배포 과정 중에 `leader-lock`을 점유중인 블루 컨테이너가 종료되고 그린 컨테이너가 리더를 가져가는 상황에서 소켓을 재연결하지 못했음(않았음). 또한 시장이 열려있는지 유무를 확인하지 않고 경합을 시작하는것도 고침

---

### 🔬 Changes Detail

그린 컨테이너가 종료되면 redis 리더 락을 지우지 못하는데. 이 경우 따로 로직을 두려고 했으나 서비스 코드가 인프라를 너무 따라가기때문에 복잡성을 높인다고 판단함. 현재 리더 지속시간은 1분, 재선출 시도는 45초. 배포 시 총 15초간의 다운타임이 생기는데 이부분은 일단 감수하려고 함

추가: `external-gateway` 유닛 테스트 생성, 'leader-election' 통합 테스트 생성
---
