### PR TITLE
Create WebSocket Fallback Logic based on Service Priority in `ExternalApiModule`

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,7 +6,10 @@ events {
 }
 
 http {
+    resolver 127.0.0.11 valid=10s;
+
     upstream backend_servers {
+        zone backend_servers 64k;
         least_conn;
         server blue:3000 resolve;
         server green:3000 resolve;
@@ -14,8 +17,6 @@ http {
 
     server {
         listen 80;
-
-        resolver 127.0.0.11 valid=10s;
 
         location / {
             set $backend_servers http://backend_servers;

--- a/src/infrastructure/externals/exchange-rates/coin-api/mock/coin-api-socket-mock.service.ts
+++ b/src/infrastructure/externals/exchange-rates/coin-api/mock/coin-api-socket-mock.service.ts
@@ -11,6 +11,7 @@ export class CoinApiSocketMockService implements IExchangeRateWebSocketService {
   private readonly baseCurrency = 'KRW';
   private readonly initialRates: Record<string, number> = {};
   private readonly fluctuationRange = 0.005; // +-0.5% 정도 변동
+  private readonly socketReceiveInterval: number = 60000;
 
   constructor(private readonly eventEmitter: EventEmitter2) {
     // 초기 레이트 셋팅 (대충 임의로 0.001 ~ 0.01 사이로 세팅)
@@ -27,7 +28,7 @@ export class CoinApiSocketMockService implements IExchangeRateWebSocketService {
    */
   connect(): void {
     // 5초마다 환율 변동 시뮬레이션
-    this.subscription = interval(5000).subscribe(() => {
+    this.subscription = interval(this.socketReceiveInterval).subscribe(() => {
       const now = Date.now();
       for (const [currencyCode, baseRate] of Object.entries(
         this.initialRates,
@@ -47,8 +48,14 @@ export class CoinApiSocketMockService implements IExchangeRateWebSocketService {
       }
     });
   }
+
   disconnect(): void {
     this.subscription?.unsubscribe();
     this.subscription = null;
+  }
+
+  // always true for dev..
+  isHealthy(): boolean | null {
+    return true;
   }
 }

--- a/src/infrastructure/externals/exchange-rates/interfaces/exchange-rate-websocket.interface.ts
+++ b/src/infrastructure/externals/exchange-rates/interfaces/exchange-rate-websocket.interface.ts
@@ -1,4 +1,5 @@
 export interface IExchangeRateWebSocketService {
   connect(): void;
   disconnect(): void;
+  isHealthy(): boolean | null;
 }

--- a/src/infrastructure/externals/exchange-rates/websocket-manager.service.ts
+++ b/src/infrastructure/externals/exchange-rates/websocket-manager.service.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IExchangeRateWebSocketService } from './interfaces/exchange-rate-websocket.interface';
+import { CustomLoggerService } from '../../../common/logger/custom-logger.service';
+
+@Injectable()
+export class WebSocketManagerService implements IExchangeRateWebSocketService {
+  private primary: IExchangeRateWebSocketService;
+  private secondary: IExchangeRateWebSocketService;
+  private activeService: IExchangeRateWebSocketService | null;
+  private healthCheckInterval: NodeJS.Timeout;
+
+  constructor(
+    @Inject('PRIMARY_WEBSOCKET')
+    primaryService: IExchangeRateWebSocketService,
+    @Inject('FALLBACK_WEBSOCKET')
+    fallbackService: IExchangeRateWebSocketService,
+    private readonly loggerService: CustomLoggerService,
+  ) {
+    this.primary = primaryService;
+    this.secondary = fallbackService;
+
+    // setting active socket service
+    this.activeService = this.primary;
+  }
+
+  connect(): void {
+    this.loggerService.log('Connecting via Primary WebSocket Service...');
+    this.activeService?.connect();
+    this.startHealthCheck(); // 연결 시작과 동시에 상태 감시 시작
+  }
+
+  disconnect(): void {
+    if (this.healthCheckInterval) clearInterval(this.healthCheckInterval);
+    this.activeService?.disconnect();
+  }
+
+  isHealthy(): boolean | null {
+    return this.activeService?.isHealthy() ?? null; // <- 이건 애반데
+  }
+
+  private startHealthCheck(): void {
+    // 30초마다 활성 서비스의 상태를 체크
+    this.healthCheckInterval = setInterval(() => {
+      if (!this.activeService?.isHealthy()) {
+        this.loggerService.warn(
+          `Active WebSocket service is unhealthy. Attempting failover...`,
+        );
+        this.failover();
+      }
+    }, 30 * 1000);
+  }
+
+  private failover(): void {
+    // 현재 활성 서비스가 1순위였지만 failover시, 2순위로 전환, 컨텍스트도 변경
+    if (this.activeService === this.primary) {
+      this.loggerService.log(
+        'Failing over from Primary to Secondary WebSocket.',
+      );
+      this.primary.disconnect();
+      this.activeService = this.secondary;
+      this.activeService.connect();
+    } else {
+      // 2순위마저 실패한 경우, 아예 소켓연결 종료
+      this.primary.disconnect();
+      this.secondary.disconnect();
+
+      this.activeService?.disconnect();
+      this.activeService = null;
+
+      this.loggerService.warn('Secondary WebSocket failed!');
+    }
+  }
+}

--- a/src/infrastructure/externals/external.module.ts
+++ b/src/infrastructure/externals/external.module.ts
@@ -8,6 +8,7 @@ import { CoinApiWebSocketService } from './exchange-rates/coin-api/coin-api-ws.s
 import { CoinApiService } from './exchange-rates/coin-api/coin-api.service';
 import { FrankFurtherService } from './exchange-rates/frankfurther/frankfurther.service';
 import { CurrencyLayerService } from './exchange-rates/currencylayer/currencylayer.service';
+import { WebSocketManagerService } from './exchange-rates/websocket-manager.service';
 
 @Module({
   imports: [CoinApiModule.forRootAsync(), EventEmitterModule.forRoot()],
@@ -25,12 +26,20 @@ import { CurrencyLayerService } from './exchange-rates/currencylayer/currencylay
       useClass: FrankFurtherService,
     },
     {
-      provide: 'WEBSOCKET_IMPL',
+      provide: 'HISTORICAL_RATE_API',
+      useClass: CurrencyLayerService,
+    },
+    {
+      provide: 'PRIMARY_WEBSOCKET',
       useClass: CoinApiWebSocketService,
     },
     {
-      provide: 'HISTORICAL_RATE_API',
-      useClass: CurrencyLayerService,
+      provide: 'FALLBACK_WEBSOCKET',
+      useClass: CoinApiSocketMockService,
+    },
+    {
+      provide: 'WEBSOCKET_IMPL',
+      useClass: WebSocketManagerService,
     },
     ExternalWebSocketGateWay,
   ],
@@ -38,8 +47,8 @@ import { CurrencyLayerService } from './exchange-rates/currencylayer/currencylay
     'LATEST_EXCHANGE_RATE_API',
     'FLUCTUATION_RATE_API',
     'TIMESERIES_RATE_API',
-    'WEBSOCKET_IMPL',
     'HISTORICAL_RATE_API',
+    'WEBSOCKET_IMPL',
     ExternalWebSocketGateWay,
   ],
 })


### PR DESCRIPTION
### 🚀 Summary
Defined socket `fallback strategy` to prepare for eternal api disability

---

### 💡 Motivation and Context
I faced several issue about `Quota exceeded` from External api when try connect to external websocket.

so, Defined `WebsocketManagerService` and create fallback strategy.
And declared `PRIMARY_WEBSOCKET`, `FALLBACK_WEBSOCKET` in `ExternalApiModule`.

---

